### PR TITLE
Switch docs to Just the Docs theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+
+gem 'just-the-docs'

--- a/README.md
+++ b/README.md
@@ -115,3 +115,14 @@ Dieses Kapitel gibt einen Überblick über die sicherheitsrelevanten Funktionen 
 - [Benutzerrollen und Berechtigungen](docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md)
 - [Passwortverwaltung](docs/sicherheitsmanagement/passwortverwaltung.md)
 - [Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle](docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md)
+
+## Lokale Vorschau
+
+Die Dokumentation nutzt jetzt das **Just the Docs** Theme. Um die Seite lokal zu testen, wird Ruby mit Bundler benötigt. Anschließend können die Abhängigkeiten installiert und der Server gestartet werden:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+Der Server läuft danach unter http://localhost:4000.

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,16 @@
-theme: jekyll-theme-cayman
+# General configuration for Jekyll
+
+# Set the site title
+title: calServer Manual
+
+# Use the modern "Just the Docs" theme
+remote_theme: just-the-docs/just-the-docs
+
+# Enable search (default for the theme)
+search_enabled: true
+
+# Color scheme can be light or dark
+color_scheme: light
+
+# Collections or defaults can be added here later
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+---
+layout: home
+title: calServer Manual
+nav_order: 1
+---
+
+# Willkommen zum calServer Manual
+
+Diese Dokumentation befindet sich im Aufbau. Das Handbuch sammelt alle wichtigen Informationen zur Nutzung und Administration von **calServer**.
+
+Weitere Inhalte finden sich in den einzelnen Kapiteln dieser Dokumentation.


### PR DESCRIPTION
## Summary
- use the Just the Docs theme via remote theme
- add Gemfile for local development
- create a docs homepage
- document how to run a local preview

## Testing
- `bundle install` *(fails: Could not fetch specs)*