### PR TITLE
Add missing subsection links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,69 +4,23 @@ Dies ist die Dokumentation zu **calServer**. Das Projekt nutzt GitHub Pages, um 
 
 Die jeweils aktuelle Version des Handbuchs ist über GitHub Pages erreichbar: [https://bastelix.github.io/calserver-docu](https://bastelix.github.io/calserver-docu).
 
-## Inhaltsverzeichnis
-
-1. [Einleitung](docs/einleitung.md)
-   - [Ziel und Zweck der Anwendung](docs/einleitung/ziel-und-zweck-der-anwendung.md)
-   - [Überblick über die Funktionen](docs/einleitung/ueberblick-ueber-die-funktionen.md)
-   - [Systemanforderungen](docs/einleitung/systemanforderungen.md)
-2. [Benutzeroberfläche](docs/benutzeroberflaeche.md)
-   - [Hauptmenü und Navigation](docs/benutzeroberflaeche/hauptmenue-und-navigation.md)
-   - [Das Grid](docs/benutzeroberflaeche/das-grid.md)
-   - [Infoleiste (TOP Menü)](docs/benutzeroberflaeche/infoleiste-top-menue.md)
-   - [Benutzerprofil – Einstellungen und Verwaltung](docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md)
-3. [Schnelleinstieg und zentrale Arbeitsabläufe](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe.md)
-   - [Schnelleinstieg: Praxisbeispiel](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md)
-   - [Minimale Grundeinrichtung des Systems](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md)
-4. [Anwendungsfunktionen](docs/anwendungsfunktionen.md)
-   - [Startcenter](docs/anwendungsfunktionen/startcenter.md)
-   - [Inventare](docs/anwendungsfunktionen/inventare.md)
-   - [Kalibrierungen](docs/anwendungsfunktionen/kalibrierungen.md)
-   - [Wartung und Reparaturen](docs/anwendungsfunktionen/wartung-und-reparaturen.md)
-   - [Leihmessmittel](docs/anwendungsfunktionen/leihmessmittel.md)
-   - [Aufträge](docs/anwendungsfunktionen/auftraege.md)
-   - [Preise](docs/anwendungsfunktionen/preise.md)
-   - [Aufgaben](docs/anwendungsfunktionen/aufgaben.md)
-   - [Kunden](docs/anwendungsfunktionen/kunden.md)
-   - [Dateien](docs/anwendungsfunktionen/dateien.md)
-   - [Support-Ticketsystem](docs/anwendungsfunktionen/support-ticketsystem.md)
-   - [Dokumentationssystem](docs/anwendungsfunktionen/dokumentationssystem.md)
-5. [Administration](docs/administration.md)
-   - [Grundeinstellungen](docs/administration/grundeinstellungen.md)
-   - [Benutzerverwaltung](docs/administration/benutzerverwaltung.md)
-   - [Statusverwaltung](docs/administration/statusverwaltung.md)
-   - [Feldverwaltung](docs/administration/feldverwaltung.md)
-   - [E-Mail-Verwaltung](docs/administration/email-verwaltung.md)
-   - [Dateiverwaltung](docs/administration/dateiverwaltung.md)
-   - [Berichtsverwaltung](docs/administration/berichtsverwaltung.md)
-   - [Synchronisation](docs/administration/synchronisation.md)
-   - [Backup- und Wiederherstellungsmanagement](docs/administration/backup-wiederherstellungsmanagement.md)
-   - [Support-Verwaltung](docs/administration/support-verwaltung.md)
-   - [Steuerungen](docs/administration/steuerungen.md)
-   - [Hilfeverwaltung](docs/administration/hilfeverwaltung.md)
-   - [Informationsverwaltung](docs/administration/informationsverwaltung.md)
-   - [Konstanten für Feldvorgaben](docs/administration/konstanten-fuer-feldvorgaben.md)
-6. [Technische Informationen](docs/technische-informationen.md)
-   - [Systemanforderungen](docs/technische-informationen/systemanforderungen.md)
-   - [Installation und Konfiguration](docs/technische-informationen/installation-und-konfiguration.md)
-   - [Fehlerbehebung, Logs und Diagnose](docs/technische-informationen/fehlerbehebung-logs-diagnose.md)
-   - [CalServer interne Hilfsfunktionen](docs/technische-informationen/calserver-interne-hilfsfunktionen.md)
-   - [Sicherheitsrichtlinien](docs/technische-informationen/sicherheitsrichtlinien.md)
-   - [REST API – Schnittstellen & Integration](docs/technische-informationen/rest-api-schnittstellen-integration.md)
-7. [Sicherheitsmanagement](docs/sicherheitsmanagement.md)
-   - [Benutzerrollen und Berechtigungen](docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md)
-   - [Passwortverwaltung](docs/sicherheitsmanagement/passwortverwaltung.md)
-   - [Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle](docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md)
-8. [Abomodelle](docs/abomodelle.md)
-
 ## Einleitung
 Dieses Kapitel führt Sie gezielt in die Anwendung calServer ein. Sie erfahren, welchen Nutzen die Software für Ihre tägliche Arbeit bietet, erhalten einen kompakten Überblick über den Funktionsumfang und lernen die grundlegenden technischen Anforderungen kennen, um optimal mit calServer zu arbeiten.
+- [Ziel und Zweck der Anwendung](docs/einleitung/ziel-und-zweck-der-anwendung.md)
+- [Überblick über die Funktionen](docs/einleitung/ueberblick-ueber-die-funktionen.md)
+- [Systemanforderungen](docs/einleitung/systemanforderungen.md)
 
 ## Benutzeroberfläche
 Dieses Kapitel bietet Ihnen eine übersichtliche Einführung in den Aufbau und die wichtigsten Funktionen der calServer-Benutzeroberfläche – von der Navigation über die Nutzung zentraler Bedienelemente bis hin zur Anpassung der Arbeitsumgebung nach individuellen Anforderungen.
+- [Hauptmenü und Navigation](docs/benutzeroberflaeche/hauptmenue-und-navigation.md)
+- [Das Grid](docs/benutzeroberflaeche/das-grid.md)
+- [Infoleiste (TOP Menü)](docs/benutzeroberflaeche/infoleiste-top-menue.md)
+- [Benutzerprofil – Einstellungen und Verwaltung](docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md)
 
 ## Schnelleinstieg und zentrale Arbeitsabläufe
 Dieses Kapitel bietet Ihnen einen kompakten, praxisnahen Einstieg in die zentralen Arbeitsabläufe von calServer – von der Datenerfassung über die systematische Grundeinrichtung bis hin zur Nutzerverwaltung.
+- [Schnelleinstieg: Praxisbeispiel](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md)
+- [Minimale Grundeinrichtung des Systems](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md)
 
 ## Anwendungsfunktionen
 Dieses Kapitel stellt Ihnen die wichtigsten Anwendungsfunktionen von calServer im Detail vor. Sie erhalten praktische Einblicke und Erklärungen zu den verschiedenen Modulen, um die Arbeitsprozesse rund um Inventarverwaltung, Kalibrierungen, Wartungen und weitere Aufgaben effizient und zielgerichtet durchführen zu können.


### PR DESCRIPTION
## Summary
- add bullet links for intro, UI and quick start
- keep auto-generated navigation by removing redundant TOC

## Testing
- `grep -oE '\(docs[^)]*\.md\)' README.md | tr -d '()' | wc -l`
- `for f in $(grep -oE '\(docs[^)]*\.md\)' README.md | tr -d '()'); do [ -f "$f" ] || echo "Missing $f"; done`
- `bundle install` *(fails: could not fetch gems)*
- `bundle exec jekyll build` *(fails: jekyll not installed)*