### PR TITLE
Update start page with detailed intro and changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,12 @@
+---
+title: Changelog
+nav_order: 10
+layout: page
+---
+
+# Changelog
+
+Hier finden Sie eine Übersicht der wichtigsten Änderungen und Versionshinweise zu calServer.
+
+Noch in Bearbeitung.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,50 @@ title: calServer Manual
 nav_order: 1
 ---
 
+*Stand: 2025-05-26*
+
+Hier ein Vorschlag, wie du die **Ankündigung für ein Manual**, die **Lizenzbedingungen** und die **Erklärung des Programms** für das calServer-Manual ausführlicher, ansprechender und professioneller gestalten kannst.
+
 # Willkommen zum calServer Manual
 
-Diese Dokumentation befindet sich im Aufbau. Das Handbuch sammelt alle wichtigen Informationen zur Nutzung und Administration von **calServer**.
+**Herzlich willkommen zur offiziellen Dokumentation von calServer!**
 
-Weitere Inhalte finden sich in den einzelnen Kapiteln dieser Dokumentation.
+Dieses Handbuch dient als zentrale Anlaufstelle für alle Informationen rund um die Nutzung, Konfiguration und Administration von calServer – Ihrer umfassenden Lösung für das Management von Inventar, Kalibrierung und Wartung in modernen Labor- und Serviceumgebungen.
+
+## Was ist calServer?
+
+calServer ist eine leistungsfähige, flexible und DSGVO-konforme Plattform für das digitale Prüfmittelmanagement, die Kalibrier-, Wartungs- und Dokumentationsprozesse in Unternehmen jeder Größe automatisiert und optimiert. Die Anwendung unterstützt Sie von der systematischen Inventarisierung über die Terminüberwachung bis hin zum automatisierten Berichtswesen. Dank moderner Webtechnologien ist calServer sowohl als Cloud-Lösung als auch On-Premises einsetzbar und kann durch eine Vielzahl von Modulen und Schnittstellen flexibel an Ihre Bedürfnisse angepasst werden.
+
+## Aufbau und Ziel dieses Handbuchs
+
+Dieses Manual vermittelt Ihnen:
+
+* Einen praxisnahen Einstieg in die Arbeit mit calServer
+* Detaillierte Schritt-für-Schritt-Anleitungen zur Bedienung und Administration
+* Hilfreiche Tipps für die tägliche Arbeit und Fehlerbehebung
+* Technische Hintergründe, API-Referenz und Integrationsmöglichkeiten
+
+Die Dokumentation wird fortlaufend erweitert und aktualisiert. Schauen Sie regelmäßig vorbei, um von neuen Inhalten und Best Practices zu profitieren.
+
+## Lizenzbedingungen
+
+calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz.
+Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden.
+Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers.
+
+Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten.
+Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+
+## Datenschutz und Hosting
+
+calServer erfüllt sämtliche Vorgaben der Datenschutz-Grundverordnung (DSGVO). Sie können zwischen einer Cloud-Lösung mit Hosting in zertifizierten Rechenzentren innerhalb Deutschlands und der EU oder einer eigenständigen On-Premises-Installation wählen.
+
+## Kontakt und Support
+
+Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team gerne zur Verfügung.
+Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com/support](https://calserver.com/support)
+
+---
+
+[Changelog](changelog.md)
+


### PR DESCRIPTION
## Summary
- extend the manual's start page with a detailed introduction
- highlight DSGVO compliance and hosting locations
- add a reference to a new changelog page

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: could not fetch gems)*