### PR TITLE
Merge manual pages and remove subpage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,51 @@
 # calServer Manual
 
-Dies ist die Dokumentation zu **calServer**. Das Projekt nutzt GitHub Pages, um die Handbücher und technischen Informationen bereitzustellen.
+*Stand: 2025-05-26*
 
-Die jeweils aktuelle Version des Handbuchs ist über GitHub Pages erreichbar: [https://bastelix.github.io/calserver-docu](https://bastelix.github.io/calserver-docu).
+Dies ist die Dokumentation zu **calServer**. Das Projekt nutzt GitHub Pages, um die Handbücher und technischen Informationen bereitzustellen. Die jeweils aktuelle Version des Handbuchs ist über GitHub Pages erreichbar: [https://bastelix.github.io/calserver-docu](https://bastelix.github.io/calserver-docu).
 
-## Einleitung
-Dieses Kapitel führt Sie gezielt in die Anwendung calServer ein. Sie erfahren, welchen Nutzen die Software für Ihre tägliche Arbeit bietet, erhalten einen kompakten Überblick über den Funktionsumfang und lernen die grundlegenden technischen Anforderungen kennen, um optimal mit calServer zu arbeiten.
-- [Ziel und Zweck der Anwendung](docs/einleitung/ziel-und-zweck-der-anwendung.md)
-- [Überblick über die Funktionen](docs/einleitung/ueberblick-ueber-die-funktionen.md)
-- [Systemanforderungen](docs/einleitung/systemanforderungen.md)
+## Willkommen zum calServer Manual
 
-## Benutzeroberfläche
-Dieses Kapitel bietet Ihnen eine übersichtliche Einführung in den Aufbau und die wichtigsten Funktionen der calServer-Benutzeroberfläche – von der Navigation über die Nutzung zentraler Bedienelemente bis hin zur Anpassung der Arbeitsumgebung nach individuellen Anforderungen.
-- [Hauptmenü und Navigation](docs/benutzeroberflaeche/hauptmenue-und-navigation.md)
-- [Das Grid](docs/benutzeroberflaeche/das-grid.md)
-- [Infoleiste (TOP Menü)](docs/benutzeroberflaeche/infoleiste-top-menue.md)
-- [Benutzerprofil – Einstellungen und Verwaltung](docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md)
+**Herzlich willkommen zur offiziellen Dokumentation von calServer!**
 
-## Schnelleinstieg und zentrale Arbeitsabläufe
-Dieses Kapitel bietet Ihnen einen kompakten, praxisnahen Einstieg in die zentralen Arbeitsabläufe von calServer – von der Datenerfassung über die systematische Grundeinrichtung bis hin zur Nutzerverwaltung.
-- [Schnelleinstieg: Praxisbeispiel](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md)
-- [Minimale Grundeinrichtung des Systems](docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md)
+Dieses Handbuch dient als zentrale Anlaufstelle für alle Informationen rund um die Nutzung, Konfiguration und Administration von calServer – Ihrer umfassenden Lösung für das Management von Inventar, Kalibrierung und Wartung in modernen Labor- und Serviceumgebungen.
 
-## Anwendungsfunktionen
-Dieses Kapitel stellt Ihnen die wichtigsten Anwendungsfunktionen von calServer im Detail vor. Sie erhalten praktische Einblicke und Erklärungen zu den verschiedenen Modulen, um die Arbeitsprozesse rund um Inventarverwaltung, Kalibrierungen, Wartungen und weitere Aufgaben effizient und zielgerichtet durchführen zu können.
+## Was ist calServer?
 
-- [Startcenter](docs/anwendungsfunktionen/startcenter.md)
-- [Inventare](docs/anwendungsfunktionen/inventare.md)
-- [Kalibrierungen](docs/anwendungsfunktionen/kalibrierungen.md)
-- [Wartung und Reparaturen](docs/anwendungsfunktionen/wartung-und-reparaturen.md)
-- [Leihmessmittel](docs/anwendungsfunktionen/leihmessmittel.md)
-- [Aufträge](docs/anwendungsfunktionen/auftraege.md)
-- [Preise](docs/anwendungsfunktionen/preise.md)
-- [Aufgaben](docs/anwendungsfunktionen/aufgaben.md)
-- [Kunden](docs/anwendungsfunktionen/kunden.md)
-- [Dateien](docs/anwendungsfunktionen/dateien.md)
-- [Support-Ticketsystem](docs/anwendungsfunktionen/support-ticketsystem.md)
-- [Dokumentationssystem](docs/anwendungsfunktionen/dokumentationssystem.md)
+calServer ist eine leistungsfähige, flexible und DSGVO-konforme Plattform für das digitale Prüfmittelmanagement, die Kalibrier-, Wartungs- und Dokumentationsprozesse in Unternehmen jeder Größe automatisiert und optimiert. Die Anwendung unterstützt Sie von der systematischen Inventarisierung über die Terminüberwachung bis hin zum automatisierten Berichtswesen. Dank moderner Webtechnologien ist calServer sowohl als Cloud-Lösung als auch On-Premises einsetzbar und kann durch eine Vielzahl von Modulen und Schnittstellen flexibel an Ihre Bedürfnisse angepasst werden.
 
-## Administration
-In diesem Kapitel erhalten Sie einen umfassenden Überblick über alle administrativen Funktionen von calServer. Erfahren Sie, wie Sie Grundeinstellungen vornehmen, Benutzer verwalten, Rollen und Berechtigungen definieren sowie zentrale Systemeinstellungen und Sicherheitsmaßnahmen effektiv einsetzen und verwalten.
+## Aufbau und Ziel dieses Handbuchs
 
-- [Grundeinstellungen](docs/administration/grundeinstellungen.md)
-- [Benutzerverwaltung](docs/administration/benutzerverwaltung.md)
-- [Statusverwaltung](docs/administration/statusverwaltung.md)
-- [Feldverwaltung](docs/administration/feldverwaltung.md)
-- [E-Mail-Verwaltung](docs/administration/email-verwaltung.md)
-- [Dateiverwaltung](docs/administration/dateiverwaltung.md)
-- [Berichtsverwaltung](docs/administration/berichtsverwaltung.md)
-- [Synchronisation](docs/administration/synchronisation.md)
-- [Backup- und Wiederherstellungsmanagement](docs/administration/backup-wiederherstellungsmanagement.md)
-- [Support-Verwaltung](docs/administration/support-verwaltung.md)
-- [Steuerungen](docs/administration/steuerungen.md)
-- [Hilfeverwaltung](docs/administration/hilfeverwaltung.md)
-- [Informationsverwaltung](docs/administration/informationsverwaltung.md)
-- [Konstanten für Feldvorgaben](docs/administration/konstanten-fuer-feldvorgaben.md)
+Dieses Manual vermittelt Ihnen:
 
-## Technische Informationen
-In diesem Kapitel finden Sie detaillierte technische Informationen zu calServer, einschließlich Systemanforderungen, Installationsanweisungen, Hilfestellungen bei Fehlern und Problemen sowie Erläuterungen zu den internen Hilfsfunktionen und der integrierten REST-API für externe Schnittstellenkommunikation.
+* Einen praxisnahen Einstieg in die Arbeit mit calServer
+* Detaillierte Schritt-für-Schritt-Anleitungen zur Bedienung und Administration
+* Hilfreiche Tipps für die tägliche Arbeit und Fehlerbehebung
+* Technische Hintergründe, API-Referenz und Integrationsmöglichkeiten
 
-- [Systemanforderungen](docs/technische-informationen/systemanforderungen.md)
-- [Installation und Konfiguration](docs/technische-informationen/installation-und-konfiguration.md)
-- [Fehlerbehebung, Logs und Diagnose](docs/technische-informationen/fehlerbehebung-logs-diagnose.md)
-- [CalServer interne Hilfsfunktionen](docs/technische-informationen/calserver-interne-hilfsfunktionen.md)
-- [Sicherheitsrichtlinien](docs/technische-informationen/sicherheitsrichtlinien.md)
-- [REST API – Schnittstellen & Integration](docs/technische-informationen/rest-api-schnittstellen-integration.md)
+Die Dokumentation wird fortlaufend erweitert und aktualisiert. Schauen Sie regelmäßig vorbei, um von neuen Inhalten und Best Practices zu profitieren.
 
-## Sicherheitsmanagement
-Dieses Kapitel gibt einen Überblick über die sicherheitsrelevanten Funktionen von calServer.
-- [Benutzerrollen und Berechtigungen](docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md)
-- [Passwortverwaltung](docs/sicherheitsmanagement/passwortverwaltung.md)
-- [Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle](docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md)
+## Lizenzbedingungen
+
+calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz. Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden. Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers.
+
+Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten. Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+
+## Datenschutz und Hosting
+
+calServer erfüllt sämtliche Vorgaben der Datenschutz-Grundverordnung (DSGVO). Sie können zwischen einer Cloud-Lösung mit Hosting in zertifizierten Rechenzentren innerhalb Deutschlands und der EU oder einer eigenständigen On-Premises-Installation wählen.
+
+## Kontakt und Support
+
+Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team gerne zur Verfügung. Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com/support](https://calserver.com/support)
 
 ## Lokale Vorschau
 
-Die Dokumentation nutzt jetzt das **Just the Docs** Theme. Um die Seite lokal zu testen, wird Ruby mit Bundler benötigt. Anschließend können die Abhängigkeiten installiert und der Server gestartet werden:
+Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
 
 ```bash
 bundle install
 bundle exec jekyll serve
 ```
 
-Der Server läuft danach unter http://localhost:4000.
+Der Server läuft anschließend unter <http://localhost:4000>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 *Stand: 2025-05-26*
 
-Hier ein Vorschlag, wie du die **Ankündigung für ein Manual**, die **Lizenzbedingungen** und die **Erklärung des Programms** für das calServer-Manual ausführlicher, ansprechender und professioneller gestalten kannst.
+Dies ist die Dokumentation zu **calServer**. Das Projekt nutzt GitHub Pages, um die Handbücher und technischen Informationen bereitzustellen. Die jeweils aktuelle Version des Handbuchs ist über GitHub Pages erreichbar: [https://bastelix.github.io/calserver-docu](https://bastelix.github.io/calserver-docu).
 
 # Willkommen zum calServer Manual
 
@@ -47,7 +47,14 @@ calServer erfüllt sämtliche Vorgaben der Datenschutz-Grundverordnung (DSGVO). 
 Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team gerne zur Verfügung.
 Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com/support](https://calserver.com/support)
 
----
+## Lokale Vorschau
 
-[Changelog](changelog.md)
+Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+Der Server läuft anschließend unter <http://localhost:4000>.
 


### PR DESCRIPTION
## Summary
- merge README content into docs/index without subpage links
- simplify README to point at combined manual

## Testing
- `bundle install` *(fails: Could not fetch specs)*