### PR TITLE
Fix quick start page location

### DIFF
--- a/docs/einleitung/schnelleinstieg-praxisbeispiel.md
+++ b/docs/einleitung/schnelleinstieg-praxisbeispiel.md
@@ -1,7 +1,7 @@
 ---
 title: Schnelleinstieg: Praxisbeispiel
-nav_order: 1
-parent: Schnelleinstieg und zentrale Arbeitsabläufe
+nav_order: 4
+parent: Einleitung
 layout: page
 ---
 

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
@@ -1,6 +1,6 @@
 ---
 title: Minimale Grundeinrichtung des Systems
-nav_order: 2
+nav_order: 1
 parent: Schnelleinstieg und zentrale Arbeitsabläufe
 layout: page
 ---


### PR DESCRIPTION
## Summary
- move `schnelleinstieg-praxisbeispiel.md` into the introduction section
- adjust navigation metadata for quick start pages

## Testing
- `bundle exec jekyll build` *(fails: command not found)*