### PR TITLE
Fix duplicate landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,7 @@ aux_links:
   "Impressum": /calserver-docu/impressum
   "Kontakt": /calserver-docu/kontakt
 aux_links_new_tab: true
+
+# Exclude repository README from the generated site
+exclude:
+  - README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 layout: home
 title: calServer Manual
 nav_order: 1
+permalink: /index.html
 ---
 
 *Stand: 2025-05-26*


### PR DESCRIPTION
## Summary
- remove README from generated site
- serve documentation `index.md` as site root

## Testing
- `bundle exec jekyll build -q` *(fails: command not found)*