### PR TITLE
Fix Impressum and Kontakt links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,10 @@ title: calServer Manual
 # Use the modern "Just the Docs" theme
 remote_theme: just-the-docs/just-the-docs
 
+# Set the base URL when hosted as a project page
+url: "https://bastelix.github.io"
+baseurl: "/calserver-docu"
+
 # Enable search (default for the theme)
 search_enabled: true
 
@@ -18,7 +22,7 @@ breadcrumbs: true
 # Auxiliary links shown in the top right corner
 aux_links:
   "GitHub": https://github.com/bastelix/calserver-docu
-  "API": /api
-  "Impressum": /impressum
-  "Kontakt": /kontakt
+  "API": https://bastelix.github.io/calserver-docu/api/
+  "Impressum": https://bastelix.github.io/calserver-docu/impressum/
+  "Kontakt": https://bastelix.github.io/calserver-docu/kontakt/
 aux_links_new_tab: true

--- a/docs/impressum.md
+++ b/docs/impressum.md
@@ -2,6 +2,7 @@
 layout: page
 title: Impressum
 nav_exclude: true
+permalink: /impressum/
 ---
 
 # Impressum

--- a/docs/kontakt.md
+++ b/docs/kontakt.md
@@ -2,6 +2,7 @@
 layout: page
 title: Kontakt
 nav_exclude: true
+permalink: /kontakt/
 ---
 
 # Kontakt


### PR DESCRIPTION
## Summary
- use fully-qualified URLs for Impressum and Kontakt
- add explicit permalinks so the pages are generated at the expected paths

## Testing
- `bundle exec jekyll build` *(fails: command not found)*