### PR TITLE
Fix duplicate child links

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,5 +3,3 @@ layout: default
 ---
 
 {{ content }}
-
-{% include children.html %}


### PR DESCRIPTION
## Summary
- remove manual call to `children.html` partial from the custom page layout

## Testing
- `bundle exec jekyll build` *(fails: command not found)*