### PR TITLE
Fix navigation issue by removing colon from page title

### DIFF
--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
@@ -1,10 +1,10 @@
 ---
-title: Schnelleinstieg: Praxisbeispiel
+title: Schnelleinstieg Praxisbeispiel
 nav_order: 2
 parent: Schnelleinstieg und zentrale Arbeitsabläufe
 layout: page
 ---
 
-# Schnelleinstieg: Praxisbeispiel
+# Schnelleinstieg Praxisbeispiel
 
 Noch in Bearbeitung.


### PR DESCRIPTION
## Summary
- update the front matter of the Schnelleinstieg Praxisbeispiel page
- remove the colon from the main heading

## Testing
- `bundle install` *(fails: no network access)*