### PR TITLE
Disable automatic table of contents

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,1 @@
+<!-- Table of contents disabled -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,5 +3,3 @@ layout: default
 ---
 
 {{ content }}
-
-{% include children.html %}


### PR DESCRIPTION
## Summary
- override the theme's `toc.html` include with a comment to suppress the generated Table of Contents

## Testing
- `bundle exec jekyll build` *(fails: command not found)*