### PR TITLE
Rename Leihmessmittel menu

### DIFF
--- a/docs/anwendungsfunktionen/standorte.md
+++ b/docs/anwendungsfunktionen/standorte.md
@@ -1,10 +1,10 @@
 ---
-title: Leihmessmittel
+title: Standorte
 nav_order: 5
 parent: Anwendungsfunktionen
 layout: page
 ---
 
-# Leihmessmittel
+# Standorte
 
 Noch in Bearbeitung.

--- a/docs/einleitung/ueberblick-ueber-die-funktionen.md
+++ b/docs/einleitung/ueberblick-ueber-die-funktionen.md
@@ -55,7 +55,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 6. Leihmessmittel-Verwaltung
+## 6. Standorte
 
 - **Kalendergestützte Reservierung** – Planung und Verwaltung von Messmitteln
 - **Drag & Drop-Reservierung** aus auswählbaren Listen


### PR DESCRIPTION
## Summary
- rename `Leihmessmittel` section to `Standorte`
- adjust the overview page heading

## Testing
- `bundle install` *(fails: Could not fetch specs)*