### PR TITLE
Enable Just the Docs TOC

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,5 +1,0 @@
----
-layout: default
----
-
-{{ content }}


### PR DESCRIPTION
## Summary
- remove custom `page` layout so the theme's version with the in‑page TOC is used

## Testing
- `git status --short`