### PR TITLE
Add custom OpenAI-inspired styles

### DIFF
--- a/assets/css/just-the-docs.scss
+++ b/assets/css/just-the-docs.scss
@@ -1,0 +1,93 @@
+---
+---
+
+@import "just-the-docs";
+
+// Just the Docs OpenAI-Style Override
+
+:root {
+  --color-background: #ffffff;
+  --color-sidebar: #f6f8fa;
+  --color-toc: #f6f8fa;
+  --color-primary: #3477f6;
+  --color-primary-hover: #2563eb;
+  --color-link: #3477f6;
+  --color-link-hover: #2563eb;
+  --color-text: #1a1a1a;
+  --color-border: #e2e8f0;
+  --color-code-bg: #f5f6fa;
+}
+
+body {
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.main-header, .site-header {
+  background: #fff;
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: none;
+}
+
+.sidebar, .nav-list {
+  background: var(--color-sidebar);
+  border-right: 1px solid var(--color-border);
+}
+
+.toc, .toc__sidebar {
+  background: var(--color-toc);
+  border-left: 1px solid var(--color-border);
+  padding: 1rem 1.5rem;
+  position: sticky;
+  top: 1.5rem;
+}
+
+a, .nav-list a, .toc a {
+  color: var(--color-link);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+a:hover, .nav-list a:hover, .toc a:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+code, pre {
+  background: var(--color-code-bg);
+  border-radius: 6px;
+  font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  color: var(--color-text);
+}
+
+.button, .cta, .btn {
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 6px;
+  border: none;
+  padding: 0.5em 1.2em;
+  font-weight: 600;
+  box-shadow: 0 2px 6px 0 rgba(52, 119, 246, 0.04);
+  transition: background 0.2s;
+}
+.button:hover, .cta:hover, .btn:hover {
+  background: var(--color-primary-hover);
+}
+
+hr, .main-content hr {
+  border-top: 1px solid var(--color-border);
+}
+
+@media (max-width: 850px) {
+  .sidebar, .toc, .toc__sidebar {
+    border: none;
+    background: var(--color-background);
+  }
+}
+
+@media (max-width: 600px) {
+  .toc, .toc__sidebar {
+    padding: 0.5rem 0.8rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add style overrides for Just the Docs to mimic OpenAI docs styling

## Testing
- `bundle install` *(fails: Could not fetch specs from rubygems.org)*
- `bundle exec jekyll build` *(fails: command not found because bundle install failed)*