### PR TITLE
Add Jekyll CI and update README

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,18 @@
+name: Build Jekyll site
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - run: bundle exec jekyll build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ calServer erfüllt sämtliche Vorgaben der Datenschutz-Grundverordnung (DSGVO). 
 
 Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team gerne zur Verfügung. Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com/support](https://calserver.com/support)
 
+## Automatischer Build
+
+Die Dokumentation wird bei jedem Push in das `main`-Repository automatisch mit
+GitHub Actions gebaut. Die dazugehörige Workflow-Datei befindet sich unter
+`.github/workflows/jekyll.yml` und führt `bundle exec jekyll build` aus, um sicherzustellen,
+dass alle Abhängigkeiten korrekt installiert sind.
+
 ## Lokale Vorschau
 
 Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:


### PR DESCRIPTION
## Summary
- build site with GitHub Actions using Ruby and Bundler
- document automatic build setup in README

## Testing
- `bundle exec jekyll build` *(fails: command not found)*