### PR TITLE
Ignore vendor and build output

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,18 @@
+name: Build Jekyll site
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - run: bundle exec jekyll build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/_site/
+/vendor/
+.jekyll-cache/
+.bundle/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ calServer erfüllt sämtliche Vorgaben der Datenschutz-Grundverordnung (DSGVO). 
 
 Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team gerne zur Verfügung. Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com/support](https://calserver.com/support)
 
+## Automatischer Build
+
+Die Dokumentation wird bei jedem Push in das `main`-Repository automatisch mit
+GitHub Actions gebaut. Die dazugehörige Workflow-Datei befindet sich unter
+`.github/workflows/jekyll.yml` und führt `bundle exec jekyll build` aus, um sicherzustellen,
+dass alle Abhängigkeiten korrekt installiert sind.
+
 ## Lokale Vorschau
 
 Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:

--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,4 @@ aux_links_new_tab: true
 # Exclude repository README from the generated site
 exclude:
   - README.md
+  - vendor/


### PR DESCRIPTION
## Summary
- exclude `vendor` directory from Jekyll build
- ignore build artifacts with `.gitignore`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*