### PR TITLE
Fix theme import error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
 
-gem 'just-the-docs'
-# Needed for downloading the theme as a remote dependency
-gem 'jekyll-remote-theme'
+gem 'just-the-docs', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 title: calServer Manual
 
 # Use the modern "Just the Docs" theme
-remote_theme: just-the-docs/just-the-docs
+theme: "just-the-docs"
 
 # Set the base URL when hosted as a project page
 url: "https://bastelix.github.io"
@@ -31,10 +31,6 @@ aux_links_new_tab: true
 exclude:
   - README.md
   - vendor/
-
-# Load the remote theme plugin
-plugins:
-  - jekyll-remote-theme
 
 # Ensure Sass can find theme assets when installed by Bundler
 sass:


### PR DESCRIPTION
## Summary
- use gem-based `just-the-docs` theme
- remove remote theme usage

## Testing
- `bundle exec jekyll build` *(fails: command not found)*