### PR TITLE
Fix theme Sass paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,3 @@ exclude:
   - README.md
   - vendor/
 
-# Ensure Sass can find theme assets when installed by Bundler
-sass:
-  load_paths:
-    - _sass
-    - vendor/bundle


### PR DESCRIPTION
## Summary
- remove overriding `sass.load_paths`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*