### PR TITLE
Fix Jekyll theme import error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
 
-gem 'just-the-docs', group: :jekyll_plugins
+gem 'just-the-docs', '~> 0.5.2', group: :jekyll_plugins


### PR DESCRIPTION
## Summary
- pin `just-the-docs` theme to a version compatible with GitHub Pages

## Testing
- `bundle install --local` *(fails: Could not find gem 'github-pages' in cached gems or installed locally)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*