### PR TITLE
Fix Sass load path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,3 +32,9 @@ exclude:
   - README.md
   - vendor/
 
+# Ensure Sass can find theme assets when installed by Bundler
+sass:
+  load_paths:
+    - _sass
+    - vendor/bundle
+


### PR DESCRIPTION
## Summary
- ensure the Sass converter can find theme styles by restoring vendor load paths

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*