### PR TITLE
Restore default Just the Docs setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
 
-gem 'just-the-docs', '~> 0.5.2', group: :jekyll_plugins
+gem 'just-the-docs', group: :jekyll_plugins


### PR DESCRIPTION
## Summary
- remove pinned version from Gemfile so theme uses default latest release

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org)*
- `bundle exec jekyll build` *(fails: jekyll not installed)*