### PR TITLE
Fix upload artifact action version

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,7 +25,7 @@ jobs:
           bundler-cache: true
       - run: bundle install
       - run: bundle exec jekyll build -d _site
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           path: _site
 


### PR DESCRIPTION
## Summary
- fix workflow's artifact step to use upload-artifact v2

## Testing
- `bundle install` *(fails: Failed to open TCP connection)*
- `bundle exec jekyll build -d _site` *(fails: bundler: command not found)*