### PR TITLE
Update upload-artifact action to v3

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,7 +25,7 @@ jobs:
           bundler-cache: true
       - run: bundle install
       - run: bundle exec jekyll build -d _site
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: _site
 


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v3` in the Pages build workflow

## Testing
- `bundle exec jekyll build -d _site` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*