### PR TITLE
Enable heading anchors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,9 @@ baseurl: "/calserver-docu"
 # Enable search (default for the theme)
 search_enabled: true
 
+# Enable in-page navigation (anchor links for headings)
+heading_anchors: true
+
 # Color scheme can be light or dark
 color_scheme: light
 


### PR DESCRIPTION
## Summary
- add `heading_anchors: true` to enable in-page heading anchors for Just the Docs templates

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: unable to fetch gems)*