### PR TITLE
Organize screenshot directories and revert erroneous move

### DIFF
--- a/docs/anwendungsfunktionen/startcenter.md
+++ b/docs/anwendungsfunktionen/startcenter.md
@@ -60,7 +60,7 @@ Jedes Infoelement kann über ein Kontextmenü angepasst werden:
 
 Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
-![Startcenter Übersicht](/assets/img/startcenter.png)
+![Startcenter Übersicht](/assets/img/anwendungsfunktionen/startcenter-uebersicht.png)
 {: .mb-4 }
 
 *Screenshot mit den markierten Elementen ①–⑧*

--- a/docs/assets/img/administration/README.md
+++ b/docs/assets/img/administration/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/anwendungsfunktionen/README.md
+++ b/docs/assets/img/anwendungsfunktionen/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/benutzeroberflaeche/README.md
+++ b/docs/assets/img/benutzeroberflaeche/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/einleitung/README.md
+++ b/docs/assets/img/einleitung/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/schnelleinstieg-und-zentrale-arbeitsablaeufe/README.md
+++ b/docs/assets/img/schnelleinstieg-und-zentrale-arbeitsablaeufe/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/sicherheitsmanagement/README.md
+++ b/docs/assets/img/sicherheitsmanagement/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/assets/img/technische-informationen/README.md
+++ b/docs/assets/img/technische-informationen/README.md
@@ -1,0 +1,1 @@
+# Screenshots


### PR DESCRIPTION
## Summary
- revert prior rename of `startcenter-uebersicht.png`
- add README placeholders for screenshot folders
- keep Startcenter docs referencing `startcenter-uebersicht.png`

## Testing
- `bundle exec jekyll build -q` *(fails: jekyll not installed)*