### PR TITLE
Fix Startcenter screenshot path

### DIFF
--- a/docs/anwendungsfunktionen/startcenter.md
+++ b/docs/anwendungsfunktionen/startcenter.md
@@ -60,7 +60,7 @@ Jedes Infoelement kann über ein Kontextmenü angepasst werden:
 
 Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
-![Startcenter Übersicht](/assets/img/anwendungsfunktionen/startcenter-uebersicht.png)
+![Startcenter Übersicht]({{ '/assets/img/anwendungsfunktionen/startcenter-uebersicht.png' | relative_url }})
 {: .mb-4 }
 
 *Screenshot mit den markierten Elementen ①–⑧*

--- a/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
+++ b/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
@@ -25,7 +25,7 @@ Die Navigation erfolgt über die linke Seitenleiste, die alle Hauptmodule enthä
 Über die Schnellsuche lassen sich gezielt Einträge finden, während die Infoleiste oben im System Benachrichtigungen und Systemmeldungen anzeigt.
 
 
-![Übersicht der Menüelemente](/assets/img/hauptmenue-navigation.png)
+![Übersicht der Menüelemente]({{ '/assets/img/hauptmenue-navigation.png' | relative_url }})
 {: .mb-4 }
 
 *Übersicht der Menüelemente*


### PR DESCRIPTION
## Summary
- fix Startcenter screenshot URL by applying `relative_url`
- adjust path filter for main navigation screenshot
- remove leftover placeholder file from docs assets

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*