### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore bundler vendor directory
+vendor/
+
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+
+# Other temporary files
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore Jekyll build artifacts and Bundler vendor directory

## Testing
- `git status --short`