### PR TITLE
Fix .gitignore and exclude vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore Bundler directories
+.bundle/
+vendor/
+
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+
+# Other temporary files
+.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -33,3 +33,4 @@ aux_links_new_tab: true
 # Exclude repository README from the generated site
 exclude:
   - README.md
+  - vendor/


### PR DESCRIPTION
## Summary
- add `.bundle/` to `.gitignore`
- exclude `vendor/` directory from Jekyll builds

## Testing
- `git status --short`
