### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ permissions:
 
 jobs:
   github-pages:
+    environment:
+      name: github-pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- configure the environment for the `github-pages` job

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org due to EHOSTUNREACH)*