### PR TITLE
Add faraday-retry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 
 gem 'just-the-docs'
+
+# Required for Faraday v2.x when building the site
+gem 'faraday-retry'


### PR DESCRIPTION
## Summary
- add `faraday-retry` gem to Gemfile to resolve build requirement for Faraday v2.x

## Testing
- `bundle exec jekyll build` *(fails: bundler couldn't install gems because command not found)*