### PR TITLE
Exclude screenshot READMEs from docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ aux_links:
 aux_links_new_tab: true
 
 # Exclude repository README from the generated site
-exclude:
-  - README.md
-  - vendor/
+  exclude:
+    - README.md
+    - vendor/
+    - docs/assets/img/**/README.md


### PR DESCRIPTION
## Summary
- exclude screenshot README files from docs navigation

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*