### PR TITLE
Add Pages environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   github-pages:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -25,4 +28,5 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site
-      - uses: actions/deploy-pages@v4
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- fix the Pages workflow to include an environment block

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*
- `bundle exec jekyll build` *(fails: command not found)*