### PR TITLE
Fix docs build by ignoring screenshot READMEs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,3 +33,5 @@ aux_links_new_tab: true
 # Exclude repository README from the generated site
 exclude:
   - README.md
+  # Hide placeholder READMEs within image directories
+  - docs/assets/img/**/README.md


### PR DESCRIPTION
## Summary
- prevent README files in image folders from being built

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*