### PR TITLE
Add grid overview screenshot section

### DIFF
--- a/assets/img/benutzeroberflaeche/README.md
+++ b/assets/img/benutzeroberflaeche/README.md
@@ -1,0 +1,1 @@
+# Screenshots

--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -40,7 +40,7 @@ Die Spaltensichtauswahl ermöglicht das Speichern und Umschalten zwischen versch
 
 #### 📸 Screenshot: Spaltensichtauswahl
 
-![Spaltensichtauswahl]({{ '/assets/img/benutzeroberflaeche/spaltensichtauswahl.png' | relative_url }})
+![Spaltensichtauswahl]({{ '/assets/img/benutzeroberflaeche/grid-spaltensichtauswahl.png' | relative_url }})
 
 ---
 
@@ -76,7 +76,7 @@ Mit dem Spaltenmenü steuern Nutzer\:innen, welche Spalten im Grid angezeigt und
 
 #### 📸 Screenshot: Spaltenmenü
 
-![Spaltenmenü]({{ '/assets/img/benutzeroberflaeche/spaltenmenue.png' | relative_url }})
+![Spaltenmenü]({{ '/assets/img/benutzeroberflaeche/grid-spaltenmenue.png' | relative_url }})
 
 ---
 
@@ -193,6 +193,26 @@ Unmittelbar **oberhalb** der Paginierung können je nach Modul weitere Schaltfl�
 - **Weitere Modulaktionen**: Z. B. Statuswechsel, Etikettendruck, Kalibrierung anstoßen etc.
 
 **Wichtig**: Diese Schaltflächen werden erst aktiv, wenn mindestens eine Zeile angehakt wurde und die Nutzerrolle das Ausführen dieser Aktionen zulässt.
+
+## Referenzdarstellung
+
+Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
+
+![Grid Übersicht]({{ '/assets/img/benutzeroberflaeche/grid-uebersicht.png' | relative_url }})
+{: .mb-4 }
+
+*Screenshot mit den markierten Elementen ①–⑥*
+
+## Erklärung der markierten Elemente im Screenshot
+
+| Nr. | Bezeichnung | Funktionale Erklärung |
+| --- | ----------- | -------------------- |
+| ① | **Spaltensichtauswahl** | Wechsel zwischen gespeicherten Spaltenansichten. |
+| ② | **Spaltenmenü** | Steuerung der sichtbaren Spalten und deren Reihenfolge. |
+| ③ | **Filterzeilen** | Eingrenzung der Datensätze direkt im Grid. |
+| ④ | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
+| ⑤ | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
+| ⑥ | **Paginierung** | Navigation zwischen den Seiten des Grids. |
 
 ---
 


### PR DESCRIPTION
## Summary
- update grid doc image names to match directory
- add detailed "Referenzdarstellung" screenshot section to grid page
- prepare image folder `assets/img/benutzeroberflaeche`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ccedc6d4c832b8a22b91d9e3a84bb