### PR TITLE
Fix heading for grid documentation

### DIFF
--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -5,7 +5,7 @@ parent: Benutzeroberfläche
 layout: page
 ---
 
-# 📘 Dokumentation: Grid-Funktionen in calServer
+# Grid-Funktionen in calServer
 
 ## 1. Grundlegender Aufbau des Grids
 


### PR DESCRIPTION
## Summary
- remove the book emoji from the grid documentation title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cd269cb0c832b8bb82dc4228c3398