### PR TITLE
Fix grid overview section

### DIFF
--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -16,6 +16,25 @@ Ein Grid in calServer stellt Datensätze tabellarisch dar – etwa Inventare, Au
 * **Unterer Detailbereich**: Schaltflächen für Massenaktionen
 * **Fußbereich**: Paginierung, Anzeigeoptionen
 
+### Referenzdarstellung
+
+Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
+
+![Grid Übersicht]({{ '/docs/assets/img/benutzeroberflaeche/das-grid.png' | relative_url }})
+{: .mb-4 }
+
+*Screenshot mit den markierten Elementen <span class="marker">①</span>–<span class="marker">⑥</span>*
+
+#### Erklärung der markierten Elemente
+
+| Nr. | Bezeichnung | Funktionale Erklärung |
+| --- | ----------- | -------------------- |
+| <span class="marker">①</span> | **Spaltensichtauswahl** | Wechsel zwischen gespeicherten Spaltenansichten. |
+| <span class="marker">②</span> | **Spaltenmenü** | Steuerung der sichtbaren Spalten und deren Reihenfolge. |
+| <span class="marker">③</span> | **Filterzeilen** | Eingrenzung der Datensätze direkt im Grid. |
+| <span class="marker">④</span> | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
+| <span class="marker">⑤</span> | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
+| <span class="marker">⑥</span> | **Paginierung** | Navigation zwischen den Seiten des Grids. |
 ---
 
 ## 2. Kopfbereich im Detail
@@ -116,7 +135,7 @@ Jede Zeile im Grid stellt einen vollständigen Datensatz dar. Zahlreiche Felder 
 
 #### 📸 Screenshot: Übersichtliches Grid mit Zeilenfunktionen
 
-![Übersichtliches Grid mit Zeilenfunktionen]({{ '/docs/assets/img/benutzeroberflaeche/grid-zeilenfunktionen.png' | relative_url }})
+![Übersichtliches Grid mit Zeilenfunktionen]({{ '/docs/assets/img/benutzeroberflaeche/das-grid.png' | relative_url }})
 
 ---
 
@@ -193,26 +212,6 @@ Unmittelbar **oberhalb** der Paginierung können je nach Modul weitere Schaltfl�
 - **Weitere Modulaktionen**: Z. B. Statuswechsel, Etikettendruck, Kalibrierung anstoßen etc.
 
 **Wichtig**: Diese Schaltflächen werden erst aktiv, wenn mindestens eine Zeile angehakt wurde und die Nutzerrolle das Ausführen dieser Aktionen zulässt.
-
-## Referenzdarstellung
-
-Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
-
-![Grid Übersicht]({{ '/assets/img/benutzeroberflaeche/grid-uebersicht.png' | relative_url }})
-{: .mb-4 }
-
-*Screenshot mit den markierten Elementen <span class="marker">①</span>–<span class="marker">⑥</span>*
-
-## Erklärung der markierten Elemente im Screenshot
-
-| Nr. | Bezeichnung | Funktionale Erklärung |
-| --- | ----------- | -------------------- |
-| <span class="marker">①</span> | **Spaltensichtauswahl** | Wechsel zwischen gespeicherten Spaltenansichten. |
-| <span class="marker">②</span> | **Spaltenmenü** | Steuerung der sichtbaren Spalten und deren Reihenfolge. |
-| <span class="marker">③</span> | **Filterzeilen** | Eingrenzung der Datensätze direkt im Grid. |
-| <span class="marker">④</span> | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
-| <span class="marker">⑤</span> | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
-| <span class="marker">⑥</span> | **Paginierung** | Navigation zwischen den Seiten des Grids. |
 
 ---
 


### PR DESCRIPTION
## Summary
- update screenshot path for grid overview
- move overview explanation to top of the grid page so it doesn't shift

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cdbffcf2c832b9c2dcd5a22dce0d9