### PR TITLE
Improve docs callout blocks

### DIFF
--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -184,6 +184,7 @@ Sie können Begriffe eingeben und die Suche mit Platzhaltern flexibel gestalten.
 | Aktiviertes `=` | Sucht unter Berücksichtigung der Groß- und Kleinschreibung |
 
 > **Tipp:** Nutzen Sie die Platzhalter `*` und `?`, um die Suche präziser zu gestalten. Aktivieren Sie das `=`-Symbol, wenn Sie die Groß- und Kleinschreibung berücksichtigen möchten.
+{: .tip }
 
 ---
 
@@ -211,7 +212,8 @@ Unmittelbar **oberhalb** der Paginierung können je nach Modul weitere Schaltfl�
 - **Löschen**: Entfernt die markierten Einträge (abhängig von Berechtigungen).
 - **Weitere Modulaktionen**: Z. B. Statuswechsel, Etikettendruck, Kalibrierung anstoßen etc.
 
-**Wichtig**: Diese Schaltflächen werden erst aktiv, wenn mindestens eine Zeile angehakt wurde und die Nutzerrolle das Ausführen dieser Aktionen zulässt.
+> **Wichtig:** Diese Schaltflächen werden erst aktiv, wenn mindestens eine Zeile angehakt wurde und die Nutzerrolle das Ausführen dieser Aktionen zulässt.
+{: .important }
 
 ---
 

--- a/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
+++ b/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
@@ -47,7 +47,9 @@ Das Hauptmenü von calServer ist die zentrale Navigationsstruktur und ermöglich
     - **Neue Seite** – Erstellung neuer Dokumentationsinhalte.
     - **Dokumentenliste** – Übersicht über alle hochgeladenen Dokumente.
     - **Sprachenliste** – Verwaltung der Sprachversionen von Dokumentationen.
-- **Schaukasten** – Nur Intern! Darstellung von wichtigen Informationen.
+- **Schaukasten** – Darstellung von wichtigen Informationen.
+
+> **Warnung:** Dieses Modul ist nur für den internen Gebrauch bestimmt.
 {: .warning }
 - **Schnellerfassung** – Direkte Eingabe neuer Daten ohne Umwege.
     - **Status erfassen** – Änderung des Status von Einträgen.


### PR DESCRIPTION
## Summary
- emphasize internal-only feature with warning callout
- highlight search advice with a tip callout
- mark important restriction with an important callout

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cde2d2fa4832bb69e7c2db60fb38b