### PR TITLE
Fix grid table formatting

### DIFF
--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -25,7 +25,7 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
 *Screenshot mit den markierten Elementen <span class="marker">①</span>–<span class="marker">⑥</span>*
 
-#### Erklärung der markierten Elemente
+#### 📊 Tabellarische Beschreibung (Referenzdarstellung)
 
 | Nr. | Bezeichnung | Funktionale Erklärung |
 | --- | ----------- | -------------------- |
@@ -35,6 +35,7 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 | <span class="marker">④</span> | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
 | <span class="marker">⑤</span> | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
 | <span class="marker">⑥</span> | **Paginierung** | Navigation zwischen den Seiten des Grids. |
+
 ---
 
 ## 2. Kopfbereich im Detail


### PR DESCRIPTION
## Summary
- clean up grid table formatting by adding blank line and header

## Testing
- `bundle install` *(fails: could not fetch specs)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cdf864c04832b9e1f0b3c4febdcbb