### PR TITLE
Add lightbox JS for fullscreen images

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,2 @@
 <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
+<script defer src="{{ "/assets/js/lightbox.js" | relative_url }}"></script>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,3 +2,23 @@
   font-size: 2em;
   line-height: 1;
 }
+
+/* Lightbox styles */
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.lightbox-image {
+  max-width: 90%;
+  max-height: 90%;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('main img').forEach(function(img) {
+    img.style.cursor = 'zoom-in';
+    img.addEventListener('click', function() {
+      var overlay = document.createElement('div');
+      overlay.className = 'lightbox-overlay';
+      var fullImg = document.createElement('img');
+      fullImg.src = img.src;
+      fullImg.alt = img.alt;
+      fullImg.className = 'lightbox-image';
+      overlay.appendChild(fullImg);
+      document.body.appendChild(overlay);
+      overlay.addEventListener('click', function() {
+        overlay.remove();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a small JS lightbox implementation
- style lightbox overlay in custom.css
- include the script in head_custom.html

## Testing
- `bundle install` *(fails: EHOSTUNREACH)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ce1b1b03c832b94bf03b6e4b54671