### PR TITLE
Fine‑tune marker size in text vs tables

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,9 @@
+.marker {
+  font-size: 1.5em;
+  line-height: 1;
+}
+
+/* markers inside tables should appear larger */
+table .marker {
+  font-size: 2em;
+}

--- a/docs/anwendungsfunktionen/startcenter.md
+++ b/docs/anwendungsfunktionen/startcenter.md
@@ -27,19 +27,19 @@ Das Startcenter unterstützt die modulare und visuelle Organisation betriebliche
 Das Startcenter besteht aus beliebig vielen, vom Benutzer erstellbaren **Dashboards**. Jedes Dashboard kann eigene Infoelemente enthalten, die individuell angeordnet und konfiguriert werden können.
 
 **Navigation:**
-Im linken Navigationsmenü befindet sich der Menüpunkt **„Startcenter“** (⑥). Unter diesem Punkt werden alle vorhandenen Dashboards als Unterschaltflächen aufgelistet. Der Punkt **„Tagesaufgaben“** (⑦) ist ein Beispiel für ein solches benutzerdefiniertes Dashboard.
+Im linken Navigationsmenü befindet sich der Menüpunkt **„Startcenter“** (<span class="marker">⑥</span>). Unter diesem Punkt werden alle vorhandenen Dashboards als Unterschaltflächen aufgelistet. Der Punkt **„Tagesaufgaben“** (<span class="marker">⑦</span>) ist ein Beispiel für ein solches benutzerdefiniertes Dashboard.
 
 ### Dashboard-Steuerungselemente
 
-* **① „+ Neue Übersicht“** – Erstellt ein komplett neues, leeres Dashboard zur individuellen Gestaltung mit Widgets.
-* **② „+ Hinzufügen"** – Öffnet ein Auswahlmenü zur Integration neuer Infoelemente.
-* **③ Dashboard-Teilen** – Erstellt eine schreibgeschützte Freigabe-URL zur Anzeige des Dashboards über Intranet/Internet.
+* **<span class="marker">①</span> „+ Neue Übersicht“** – Erstellt ein komplett neues, leeres Dashboard zur individuellen Gestaltung mit Widgets.
+* **<span class="marker">②</span> „+ Hinzufügen"** – Öffnet ein Auswahlmenü zur Integration neuer Infoelemente.
+* **<span class="marker">③</span> Dashboard-Teilen** – Erstellt eine schreibgeschützte Freigabe-URL zur Anzeige des Dashboards über Intranet/Internet.
 
 ## Infoelemente (Widgets)
 
 ### Hinzufügen von Infoelementen
 
-1. Öffnen Sie ein Dashboard und klicken Sie auf **„+ Hinzufügen“** (②).
+1. Öffnen Sie ein Dashboard und klicken Sie auf **„+ Hinzufügen“** (<span class="marker">②</span>).
 2. Wählen Sie ein Element aus der angezeigten Liste, gruppiert nach Themenbereichen.
 3. Bestätigen Sie mit **„Hinzufügen“** – das Widget erscheint im aktuellen Dashboard.
 
@@ -53,8 +53,8 @@ Jedes Infoelement kann über ein Kontextmenü angepasst werden:
 
 ## Beispiele für Infoelemente
 
-* **④ Letzte Kalibrierungen** – Tabellarische Übersicht der zuletzt durchgeführten Kalibrierungen.
-* **⑤ Anzahl aktive Geräte** – Anzeige der aktiven Geräteanzahl, generiert aus einem gefilterten Grid.
+* **<span class="marker">④</span> Letzte Kalibrierungen** – Tabellarische Übersicht der zuletzt durchgeführten Kalibrierungen.
+* **<span class="marker">⑤</span> Anzahl aktive Geräte** – Anzeige der aktiven Geräteanzahl, generiert aus einem gefilterten Grid.
 
 ## Referenzdarstellung
 
@@ -63,20 +63,20 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 ![Startcenter Übersicht]({{ '/docs/assets/img/anwendungsfunktionen/startcenter-uebersicht.png' | relative_url }})
 {: .mb-4 }
 
-*Screenshot mit den markierten Elementen ①–⑧*
+*Screenshot mit den markierten Elementen <span class="marker">①</span>–<span class="marker">⑧</span>*
 
 ## Erklärung der markierten Elemente im Screenshot
 
 | Nr. | Bezeichnung | Funktionale Erklärung |
 | --- | ----------- | -------------------- |
-| ① | **+ Neue Übersicht** | Erstellt ein neues, leeres Dashboard zur individuellen Gestaltung. |
-| ② | **+ Hinzufügen** | Fügt ein neues Infoelement (Widget) in das aktuelle Dashboard ein. |
-| ③ | **Dashboard teilen** | Generiert eine Read-only-Ansicht des Dashboards zur Weitergabe. |
-| ④ | **Letzte Kalibrierungen (Widget)** | Zeigt vergangene Kalibrierereignisse tabellarisch an. |
-| ⑤ | **Anzahl aktive Geräte (Widget)** | Visualisiert die Menge aktiver Geräte auf Basis eines Filters. |
-| ⑥ | **Startcenter (Menüpunkt)** | Hauptnavigationspunkt zur Anzeige aller Dashboards. |
-| ⑦ | **Dashboard „Tagesaufgaben“** | Beispiel für ein individuelles Dashboard mit Tagesinformationen. |
-| ⑧ | **Optionsmenü eines Dashboards** | Kontextmenü mit Funktionen wie **Aktiv**, **Umbenennen** und **Löschen**. |
+| <span class="marker">①</span> | **+ Neue Übersicht** | Erstellt ein neues, leeres Dashboard zur individuellen Gestaltung. |
+| <span class="marker">②</span> | **+ Hinzufügen** | Fügt ein neues Infoelement (Widget) in das aktuelle Dashboard ein. |
+| <span class="marker">③</span> | **Dashboard teilen** | Generiert eine Read-only-Ansicht des Dashboards zur Weitergabe. |
+| <span class="marker">④</span> | **Letzte Kalibrierungen (Widget)** | Zeigt vergangene Kalibrierereignisse tabellarisch an. |
+| <span class="marker">⑤</span> | **Anzahl aktive Geräte (Widget)** | Visualisiert die Menge aktiver Geräte auf Basis eines Filters. |
+| <span class="marker">⑥</span> | **Startcenter (Menüpunkt)** | Hauptnavigationspunkt zur Anzeige aller Dashboards. |
+| <span class="marker">⑦</span> | **Dashboard „Tagesaufgaben“** | Beispiel für ein individuelles Dashboard mit Tagesinformationen. |
+| <span class="marker">⑧</span> | **Optionsmenü eines Dashboards** | Kontextmenü mit Funktionen wie **Aktiv**, **Umbenennen** und **Löschen**. |
 
 ## Übersicht der Infoelemente (Widgets)
 
@@ -109,13 +109,13 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
 ## Persönliche Startseite konfigurieren
 
-Über das Optionsmenü eines Dashboards (**⑧**) kann dieses als **persönliche Startseite** markiert werden – es erscheint dann automatisch nach jedem Login.
+Über das Optionsmenü eines Dashboards (**<span class="marker">⑧</span>**) kann dieses als **persönliche Startseite** markiert werden – es erscheint dann automatisch nach jedem Login.
 
 ## Funktionale Hinweise zur Bedienung
 
 * Dashboards sind modular und frei konfigurierbar.
 * Widgets unterstützen Filterlogiken, Sortierungen und unterschiedliche Visualisierungen.
-* Die Dashboard-Freigabe (③) ermöglicht kontrollierte Informationsweitergabe ohne Bearbeitungsrechte.
-* Navigation über das Menü **„Startcenter“** (⑥) erlaubt schnelles Umschalten zwischen Dashboards.
-* Verwaltung über **Optionsmenü (⑧)** erlaubt persönliche Strukturierung und Pflege der Navigation.
+* Die Dashboard-Freigabe (<span class="marker">③</span>) ermöglicht kontrollierte Informationsweitergabe ohne Bearbeitungsrechte.
+* Navigation über das Menü **„Startcenter“** (<span class="marker">⑥</span>) erlaubt schnelles Umschalten zwischen Dashboards.
+* Verwaltung über **Optionsmenü (<span class="marker">⑧</span>)** erlaubt persönliche Strukturierung und Pflege der Navigation.
 

--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -48,10 +48,10 @@ Die Spaltensichtauswahl ermöglicht das Speichern und Umschalten zwischen versch
 
 | Nr. | Element                     | Beschreibung                                                            |
 | --- | --------------------------- | ----------------------------------------------------------------------- |
-| ①   | Aktive Ansicht („Standard") | Aktuell ausgewählte Spaltenansicht, `*` zeigt ungespeicherte Änderungen |
-| ②   | Ansichtsauswahl             | Dropdown-Liste gespeicherter benutzerdefinierter Ansichten              |
-| ③   | Bearbeitungsfunktionen      | Icons für Umbenennen, Löschen und Speichern                             |
-| ④   | Speichern als               | Speichert aktuelle Konfiguration als neue Ansicht                       |
+| <span class="marker">①</span>   | Aktive Ansicht („Standard") | Aktuell ausgewählte Spaltenansicht, `*` zeigt ungespeicherte Änderungen |
+| <span class="marker">②</span>   | Ansichtsauswahl             | Dropdown-Liste gespeicherter benutzerdefinierter Ansichten              |
+| <span class="marker">③</span>   | Bearbeitungsfunktionen      | Icons für Umbenennen, Löschen und Speichern                             |
+| <span class="marker">④</span>   | Speichern als               | Speichert aktuelle Konfiguration als neue Ansicht                       |
 
 ---
 
@@ -84,12 +84,12 @@ Mit dem Spaltenmenü steuern Nutzer\:innen, welche Spalten im Grid angezeigt und
 
 | Nr. | Element             | Beschreibung                                   |
 | --- | ------------------- | ---------------------------------------------- |
-| ①   | Spaltenmenü öffnen  | Aufruf der Konfiguration sichtbarer Spalten    |
-| ②   | Spaltencheckboxen   | Schalten Sichtbarkeit einzelner Spalten an/aus |
-| ③   | Drag & Drop-Bereich | Neuanordnung der Spalten durch Ziehen          |
-| ④   | Suchfeld            | Schnelle Filterung nach Spaltennamen           |
-| ⑤   | OK-Schaltfläche     | Bestätigt Änderungen                           |
-| ⑥   | Rücksetzen          | Lädt systemseitige oder gespeicherte Vorlage   |
+| <span class="marker">①</span>   | Spaltenmenü öffnen  | Aufruf der Konfiguration sichtbarer Spalten    |
+| <span class="marker">②</span>   | Spaltencheckboxen   | Schalten Sichtbarkeit einzelner Spalten an/aus |
+| <span class="marker">③</span>   | Drag & Drop-Bereich | Neuanordnung der Spalten durch Ziehen          |
+| <span class="marker">④</span>   | Suchfeld            | Schnelle Filterung nach Spaltennamen           |
+| <span class="marker">⑤</span>   | OK-Schaltfläche     | Bestätigt Änderungen                           |
+| <span class="marker">⑥</span>   | Rücksetzen          | Lädt systemseitige oder gespeicherte Vorlage   |
 
 ---
 
@@ -124,13 +124,13 @@ Jede Zeile im Grid stellt einen vollständigen Datensatz dar. Zahlreiche Felder 
 
 | Nr. | Element                    | Beschreibung                                                  |
 | --- | -------------------------- | ------------------------------------------------------------- |
-| ①   | Spaltenfilter              | Zeilen unter den Spaltenköpfen zur Eingrenzung der Datensätze |
-| ②   | Spaltensichtauswahl        | Dropdown zum Wechsel zwischen gespeicherten Konfigurationen   |
-| ③   | Kopfbereichsmenü           | Filteroptionen, Spaltensteuerung und Aktionen                 |
-| ④   | Verlinkte Datenzellen      | Klickbare Felder zur Navigation in Detailansichten            |
-| ⑤   | Zeilenaktionsmenü          | Kontextmenü mit spezifischen Bearbeitungsoptionen             |
-| ⑥   | Sammelaktionsleiste        | Aktionen für ausgewählte Datensätze (Mehrfachselektion)       |
-| ⑦   | Fußbereich mit Paginierung | Navigation zwischen Seiten, Auswahl Zeilen pro Seite          |
+| <span class="marker">①</span>   | Spaltenfilter              | Zeilen unter den Spaltenköpfen zur Eingrenzung der Datensätze |
+| <span class="marker">②</span>   | Spaltensichtauswahl        | Dropdown zum Wechsel zwischen gespeicherten Konfigurationen   |
+| <span class="marker">③</span>   | Kopfbereichsmenü           | Filteroptionen, Spaltensteuerung und Aktionen                 |
+| <span class="marker">④</span>   | Verlinkte Datenzellen      | Klickbare Felder zur Navigation in Detailansichten            |
+| <span class="marker">⑤</span>   | Zeilenaktionsmenü          | Kontextmenü mit spezifischen Bearbeitungsoptionen             |
+| <span class="marker">⑥</span>   | Sammelaktionsleiste        | Aktionen für ausgewählte Datensätze (Mehrfachselektion)       |
+| <span class="marker">⑦</span>   | Fußbereich mit Paginierung | Navigation zwischen Seiten, Auswahl Zeilen pro Seite          |
 
 ---
 
@@ -201,18 +201,18 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 ![Grid Übersicht]({{ '/assets/img/benutzeroberflaeche/grid-uebersicht.png' | relative_url }})
 {: .mb-4 }
 
-*Screenshot mit den markierten Elementen ①–⑥*
+*Screenshot mit den markierten Elementen <span class="marker">①</span>–<span class="marker">⑥</span>*
 
 ## Erklärung der markierten Elemente im Screenshot
 
 | Nr. | Bezeichnung | Funktionale Erklärung |
 | --- | ----------- | -------------------- |
-| ① | **Spaltensichtauswahl** | Wechsel zwischen gespeicherten Spaltenansichten. |
-| ② | **Spaltenmenü** | Steuerung der sichtbaren Spalten und deren Reihenfolge. |
-| ③ | **Filterzeilen** | Eingrenzung der Datensätze direkt im Grid. |
-| ④ | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
-| ⑤ | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
-| ⑥ | **Paginierung** | Navigation zwischen den Seiten des Grids. |
+| <span class="marker">①</span> | **Spaltensichtauswahl** | Wechsel zwischen gespeicherten Spaltenansichten. |
+| <span class="marker">②</span> | **Spaltenmenü** | Steuerung der sichtbaren Spalten und deren Reihenfolge. |
+| <span class="marker">③</span> | **Filterzeilen** | Eingrenzung der Datensätze direkt im Grid. |
+| <span class="marker">④</span> | **Zeilenaktionsmenü** | Kontextmenü für Bearbeitungsoptionen einzelner Datensätze. |
+| <span class="marker">⑤</span> | **Sammelaktionsleiste** | Aktionen für alle markierten Zeilen. |
+| <span class="marker">⑥</span> | **Paginierung** | Navigation zwischen den Seiten des Grids. |
 
 ---
 


### PR DESCRIPTION
## Summary
- keep circled digit markers but adjust CSS so they are 1.5em in normal text
- enlarge markers within tables to 2em

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cd2b9fb48832bbed45069218e1b0f