### PR TITLE
Clarify local preview instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,6 @@ bundle install
 bundle exec jekyll serve
 ```
 
-Der Server läuft anschließend unter <http://localhost:4000>.
+Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+
+Praktische Beispiele für GitHub Pages Workflows finden Sie im [Starter‑Repository](https://github.com/actions/starter-workflows/tree/main/pages).

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,5 +56,7 @@ bundle install
 bundle exec jekyll serve
 ```
 
-Der Server läuft anschließend unter <http://localhost:4000>.
+Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+
+Praktische Beispiele für GitHub Pages Workflows finden Sie im [Starter‑Repository](https://github.com/actions/starter-workflows/tree/main/pages).
 


### PR DESCRIPTION
## Summary
- explain how to preview the site with the default `baseurl`
- add hint for `jekyll serve --baseurl ''`
- link to GitHub Pages starter templates

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_683d4da94714832b89438bf19efaa35e