### PR TITLE
Fix TOC display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 
 gem 'just-the-docs'
+gem 'jekyll-toc'

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,21 @@ aux_links:
   "Kontakt": https://bastelix.github.io/calserver-docu/kontakt/
 aux_links_new_tab: true
 
+# Enable table of contents generation using jekyll-toc
+plugins:
+  - jekyll-toc
+
+toc:
+  min_level: 2
+  max_level: 3
+
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      toc: true
+
 # Exclude repository README from the generated site
 exclude:
   - README.md


### PR DESCRIPTION
## Summary
- enable table of contents generation via `jekyll-toc`
- turn on table of contents by default for all pages

## Testing
- `bundle exec jekyll build -d _site` *(fails: bundler could not find jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_683d512fee44832bb5d690e8fa81f26f