### PR TITLE
Fix theme settings and toc style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 title: calServer Manual
 
 # Use the modern "Just the Docs" theme
-remote_theme: just-the-docs/just-the-docs
+theme: just-the-docs
 
 # Set the base URL when hosted as a project page
 url: "https://bastelix.github.io"

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,8 +29,17 @@ table .marker {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
-/* TOC styling for large screens */
-@media screen and (min-width: 70rem) {
+/* Basic TOC styling */
+nav.toc {
+  margin-bottom: 1rem;
+}
+nav.toc ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+/* TOC styling for medium and large screens */
+@media screen and (min-width: 60rem) {
   nav.toc {
     float: right;
     width: 18rem;


### PR DESCRIPTION
## Summary
- set `theme: just-the-docs` in `_config.yml`
- tweak TOC CSS for better page menu display

## Testing
- `bundle install` *(fails: could not fetch specs)*

------
https://chatgpt.com/codex/tasks/task_e_683d5588f298832bbdd4e5c66dc57f70