### PR TITLE
Add callouts for notes and license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ Die Dokumentation wird fortlaufend erweitert und aktualisiert. Schauen Sie regel
 
 ## Lizenzbedingungen
 
-calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz. Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden. Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers.
-
-Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten. Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+> **Wichtig:** calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz. Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden. Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers. Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten. Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+{: .important }
 
 ## Datenschutz und Hosting
 
@@ -42,13 +41,14 @@ Bei Fragen, Anregungen oder Unterstützungsbedarf steht Ihnen unser Support-Team
 
 ## Lokale Vorschau
 
-Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
-
-```bash
-bundle install
-bundle exec jekyll serve
-```
-
-Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+> **Hinweis:** Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
+> 
+> ```bash
+> bundle install
+> bundle exec jekyll serve
+> ```
+> 
+> Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+{: .note }
 
 Praktische Beispiele für GitHub Pages Workflows finden Sie im [Starter‑Repository](https://github.com/actions/starter-workflows/tree/main/pages).

--- a/docs/administration/backup-wiederherstellungsmanagement.md
+++ b/docs/administration/backup-wiederherstellungsmanagement.md
@@ -8,4 +8,5 @@ layout: page
 # Backup- und Wiederherstellungsmanagement
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/benutzerverwaltung.md
+++ b/docs/administration/benutzerverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Benutzerverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/berichtsverwaltung.md
+++ b/docs/administration/berichtsverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Berichtsverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/dateiverwaltung.md
+++ b/docs/administration/dateiverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Dateiverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/email-verwaltung.md
+++ b/docs/administration/email-verwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # E-Mail-Verwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/feldverwaltung.md
+++ b/docs/administration/feldverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Feldverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/grundeinstellungen.md
+++ b/docs/administration/grundeinstellungen.md
@@ -8,4 +8,5 @@ layout: page
 # Grundeinstellungen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/hilfeverwaltung.md
+++ b/docs/administration/hilfeverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Hilfeverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/informationsverwaltung.md
+++ b/docs/administration/informationsverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Informationsverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/konstanten-fuer-feldvorgaben.md
+++ b/docs/administration/konstanten-fuer-feldvorgaben.md
@@ -8,4 +8,5 @@ layout: page
 # Konstanten für Feldvorgaben
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/statusverwaltung.md
+++ b/docs/administration/statusverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Statusverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/steuerungen.md
+++ b/docs/administration/steuerungen.md
@@ -8,4 +8,5 @@ layout: page
 # Steuerungen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/support-verwaltung.md
+++ b/docs/administration/support-verwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Support-Verwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/administration/synchronisation.md
+++ b/docs/administration/synchronisation.md
@@ -8,4 +8,5 @@ layout: page
 # Synchronisation
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/aufgaben.md
+++ b/docs/anwendungsfunktionen/aufgaben.md
@@ -8,4 +8,5 @@ layout: page
 # Aufgaben
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/auftraege.md
+++ b/docs/anwendungsfunktionen/auftraege.md
@@ -8,4 +8,5 @@ layout: page
 # Aufträge
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/dateien.md
+++ b/docs/anwendungsfunktionen/dateien.md
@@ -8,4 +8,5 @@ layout: page
 # Dateien
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/dokumentationssystem.md
+++ b/docs/anwendungsfunktionen/dokumentationssystem.md
@@ -8,4 +8,5 @@ layout: page
 # Dokumentationssystem
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/inventare.md
+++ b/docs/anwendungsfunktionen/inventare.md
@@ -8,4 +8,5 @@ layout: page
 # Inventare
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/kalibrierungen.md
+++ b/docs/anwendungsfunktionen/kalibrierungen.md
@@ -8,4 +8,5 @@ layout: page
 # Kalibrierungen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/kunden.md
+++ b/docs/anwendungsfunktionen/kunden.md
@@ -8,4 +8,5 @@ layout: page
 # Kunden
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/preise.md
+++ b/docs/anwendungsfunktionen/preise.md
@@ -8,4 +8,5 @@ layout: page
 # Preise
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/standorte.md
+++ b/docs/anwendungsfunktionen/standorte.md
@@ -8,4 +8,5 @@ layout: page
 # Standorte
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/support-ticketsystem.md
+++ b/docs/anwendungsfunktionen/support-ticketsystem.md
@@ -8,4 +8,5 @@ layout: page
 # Support-Ticketsystem
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/anwendungsfunktionen/wartung-und-reparaturen.md
+++ b/docs/anwendungsfunktionen/wartung-und-reparaturen.md
@@ -8,4 +8,5 @@ layout: page
 # Wartung und Reparaturen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
+++ b/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Benutzerprofil – Einstellungen und Verwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/benutzeroberflaeche/infoleiste-top-menue.md
+++ b/docs/benutzeroberflaeche/infoleiste-top-menue.md
@@ -8,4 +8,5 @@ layout: page
 # Infoleiste (TOP Menü)
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,12 +31,8 @@ Die Dokumentation wird fortlaufend erweitert und aktualisiert. Schauen Sie regel
 
 ## Lizenzbedingungen
 
-calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz.
-Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden.
-Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers.
-
-Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten.
-Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+> **Wichtig:** calServer und die zugehörige Dokumentation unterliegen urheberrechtlichem Schutz. Sofern nicht ausdrücklich anders gekennzeichnet, dürfen Inhalte dieses Manuals ausschließlich im Rahmen einer gültigen calServer-Lizenz genutzt werden. Die Weitergabe, Vervielfältigung oder Veröffentlichung – auch auszugsweise – bedarf der vorherigen schriftlichen Zustimmung des Rechteinhabers. Bitte beachten Sie zusätzlich die jeweils gültigen Endnutzer-Lizenzbedingungen (EULA), die Sie bei Erwerb oder Aktivierung von calServer erhalten. Support, Updates und Zugang zu erweiterten Inhalten sind Bestandteil eines gültigen Lizenzvertrags.
+{: .important }
 
 ## Datenschutz und Hosting
 
@@ -49,14 +45,15 @@ Weitere Informationen und Kontaktmöglichkeiten finden Sie unter: [calserver.com
 
 ## Lokale Vorschau
 
-Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
-
-```bash
-bundle install
-bundle exec jekyll serve
-```
-
-Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+> **Hinweis:** Die Dokumentation nutzt das **Just the Docs** Theme. Um die Seite lokal zu testen, benötigen Sie Ruby mit Bundler. Installieren Sie die Abhängigkeiten und starten Sie den Server mit:
+> 
+> ```bash
+> bundle install
+> bundle exec jekyll serve
+> ```
+> 
+> Mit dem in `_config.yml` gesetzten `baseurl: /calserver-docu` erscheint die Seite anschließend unter <http://localhost:4000/calserver-docu>. Für eine Vorschau direkt unter <http://localhost:4000> können Sie den Server auch mit `bundle exec jekyll serve --baseurl ''` starten.
+{: .note }
 
 Praktische Beispiele für GitHub Pages Workflows finden Sie im [Starter‑Repository](https://github.com/actions/starter-workflows/tree/main/pages).
 

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
@@ -8,4 +8,5 @@ layout: page
 # Minimale Grundeinrichtung des Systems
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
@@ -8,4 +8,5 @@ layout: page
 # Schnelleinstieg Praxisbeispiel
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
+++ b/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
@@ -8,4 +8,5 @@ layout: page
 # Benutzerrollen und Berechtigungen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/sicherheitsmanagement/passwortverwaltung.md
+++ b/docs/sicherheitsmanagement/passwortverwaltung.md
@@ -8,4 +8,5 @@ layout: page
 # Passwortverwaltung
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
+++ b/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
@@ -8,4 +8,5 @@ layout: page
 # Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
+++ b/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
@@ -8,4 +8,5 @@ layout: page
 # CalServer interne Hilfsfunktionen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
+++ b/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
@@ -8,4 +8,5 @@ layout: page
 # Fehlerbehebung, Logs und Diagnose
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/installation-und-konfiguration.md
+++ b/docs/technische-informationen/installation-und-konfiguration.md
@@ -8,4 +8,5 @@ layout: page
 # Installation und Konfiguration
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/rest-api-schnittstellen-integration.md
+++ b/docs/technische-informationen/rest-api-schnittstellen-integration.md
@@ -8,4 +8,5 @@ layout: page
 # REST API – Schnittstellen & Integration
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/sicherheitsrichtlinien.md
+++ b/docs/technische-informationen/sicherheitsrichtlinien.md
@@ -8,4 +8,5 @@ layout: page
 # Sicherheitsrichtlinien
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }

--- a/docs/technische-informationen/systemanforderungen.md
+++ b/docs/technische-informationen/systemanforderungen.md
@@ -8,4 +8,5 @@ layout: page
 # Systemanforderungen
 {% include toc.html %}
 
-Noch in Bearbeitung.
+> **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
+{: .note }


### PR DESCRIPTION
## Summary
- turn "Noch in Bearbeitung" placeholders into note callouts
- use an **important** callout for license terms in `README.md` and `index.md`
- add callout with setup commands for local preview in both docs

## Testing
- `bundle install` *(fails: Could not fetch specs)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d55dd867c832bb13ee8524b74d77d