### PR TITLE
Fix remote theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,8 @@
 # Set the site title
 title: calServer Manual
 
-# Use the modern "Just the Docs" theme
-theme: just-the-docs
+# Use the modern "Just the Docs" theme via remote theme
+remote_theme: just-the-docs/just-the-docs
 
 # Set the base URL when hosted as a project page
 url: "https://bastelix.github.io"


### PR DESCRIPTION
## Summary
- use the remote theme `just-the-docs/just-the-docs`

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_683d58a93638832b8d1de07140d2fed1