### PR TITLE
Fix headings and sidebar ToC

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -41,10 +41,12 @@ nav.toc ul {
 /* TOC styling for medium and large screens */
 @media screen and (min-width: 60rem) {
   nav.toc {
-    float: right;
-    width: 18rem;
-    margin-left: 2rem;
-    position: sticky;
+    position: fixed;
+    right: 2rem;
     top: 4rem;
+    width: 18rem;
+  }
+  main {
+    margin-right: 20rem;
   }
 }

--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -8,7 +8,7 @@ layout: page
 # Grid-Funktionen in calServer
 {% include toc.html %}
 
-## 1. Grundlegender Aufbau des Grids
+## Grundlegender Aufbau des Grids
 
 Ein Grid in calServer stellt Datensätze tabellarisch dar – etwa Inventare, Aufträge oder Prüfmittel. Es gliedert sich in:
 
@@ -39,9 +39,9 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
 ---
 
-## 2. Kopfbereich im Detail
+## Kopfbereich im Detail
 
-### 2.1 Spaltensichtauswahl
+### Spaltensichtauswahl
 
 Die Spaltensichtauswahl ermöglicht das Speichern und Umschalten zwischen verschiedenen Spaltenkonfigurationen im Grid. Dies ist hilfreich für unterschiedliche Rollen, Aufgaben oder Anwendungsfälle (z. B. kompakte vs. erweiterte Ansicht).
 
@@ -76,7 +76,7 @@ Die Spaltensichtauswahl ermöglicht das Speichern und Umschalten zwischen versch
 
 ---
 
-### 2.2 Spaltenmenü
+### Spaltenmenü
 
 Mit dem Spaltenmenü steuern Nutzer\:innen, welche Spalten im Grid angezeigt und wie diese angeordnet werden sollen.
 
@@ -114,9 +114,9 @@ Mit dem Spaltenmenü steuern Nutzer\:innen, welche Spalten im Grid angezeigt und
 
 ---
 
-## 3. Hauptteil: Tabellarische Daten & Zeilenfunktionen
+## Hauptteil: Tabellarische Daten & Zeilenfunktionen
 
-### 3.1 Interaktive Zeilenfunktionen
+### Interaktive Zeilenfunktionen
 
 Jede Zeile im Grid stellt einen vollständigen Datensatz dar. Zahlreiche Felder verfügen über **kontextbezogene Interaktionen**:
 
@@ -155,7 +155,7 @@ Jede Zeile im Grid stellt einen vollständigen Datensatz dar. Zahlreiche Felder 
 
 ---
 
-### 3.2 Suchfunktion in Tabellenfeldern
+### Suchfunktion in Tabellenfeldern
 
 In allen Tabellenfeldern steht Ihnen eine komfortable Suchfunktion zur Verfügung.
 Sie können Begriffe eingeben und die Suche mit Platzhaltern flexibel gestalten.
@@ -190,7 +190,7 @@ Sie können Begriffe eingeben und die Suche mit Platzhaltern flexibel gestalten.
 
 ---
 
-### 3.3 Zeilenfunktionen
+### Zeilenfunktionen
 
 - **Direkte Bearbeitung (rollenabhängig)**  
   Bei ausreichenden Rechten kann ein Spaltenwert direkt im Grid angeklickt werden. Ein kleines Popup erlaubt die Änderung.
@@ -204,7 +204,7 @@ Sie können Begriffe eingeben und die Suche mit Platzhaltern flexibel gestalten.
 - **Zeilenmarker**  
   Am Zeilenanfang befindet sich meist eine Checkbox, um mehrere Datensätze zu markieren und anschließend gemeinsam zu bearbeiten, zu löschen oder zu exportieren.
 
-### 3.4 Gridbezogene Schaltflächen (unterer Detailbereich)
+### Gridbezogene Schaltflächen (unterer Detailbereich)
 
 Unmittelbar **oberhalb** der Paginierung können je nach Modul weitere Schaltflächen angezeigt werden, mit denen Sie *markierte* Datensätze gemeinsam bearbeiten:
 
@@ -241,7 +241,7 @@ Nachfolgend ein Screenshot zur Veranschaulichung der beschriebenen Elemente:
 
 ---
 
-### 4. Fußbereich
+### Fußbereich
 
 Im **Fußbereich** des Grids werden vor allem **Navigations- und Anzeigeoptionen** bereitgestellt:
 
@@ -254,7 +254,7 @@ Im **Fußbereich** des Grids werden vor allem **Navigations- und Anzeigeoptionen
 
 ---
 
-## 5. Zusammenfassung
+## Zusammenfassung
 
 Die modulare Grid-Struktur von **calServer** bietet:
 

--- a/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
+++ b/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
@@ -8,15 +8,15 @@ layout: page
 # Hauptmenü und Navigation
 {% include toc.html %}
 
-## 1.1 Einführung
+## Einführung
 
 Das Hauptmenü und die Navigation in calServer sind darauf ausgelegt, eine effiziente und benutzerfreundliche Bedienung zu ermöglichen. Nutzende können schnell auf relevante Funktionen zugreifen und das System nach ihren Bedürfnissen anpassen. Die Navigation erfolgt über eine klar strukturierte Seitenleiste, die sich je nach Nutzerrolle dynamisch anpassen kann.
 
-## 1.2 Benutzerrollen und Sichtbarkeit
+## Benutzerrollen und Sichtbarkeit
 
 Das Hauptmenü ist rollenbasiert aufgebaut, was bedeutet, dass abhängig von den vergebenen Berechtigungen bestimmte Menüpunkte ein- oder ausgeblendet werden. Dies stellt sicher, dass Nutzende nur die für sie relevanten Funktionen sehen und die Benutzeroberfläche übersichtlich bleibt.
 
-## 1.3 Bedienkonzept
+## Bedienkonzept
 
 Die Navigation erfolgt über die linke Seitenleiste, die alle Hauptmodule enthält. Diese kann durch das Hamburgermenü ein- und ausgeklappt werden.
 
@@ -31,13 +31,13 @@ Die Navigation erfolgt über die linke Seitenleiste, die alle Hauptmodule enthä
 
 *Übersicht der Menüelemente*
 
-## 1.4 Anpassungsmöglichkeiten
+## Anpassungsmöglichkeiten
 
 - Die Menüstruktur kann je nach Unternehmensanforderung individuell konfiguriert werden.
 - In den Grundeinstellungen lassen sich CI-Elemente wie der Systemname anpassen.
 - Rollenbasierte Zugriffsrechte steuern, welche Nutzenden welche Menüpunkte sehen.
 
-## 1.5 Hauptmenübaum
+## Hauptmenübaum
 
 Das Hauptmenü von calServer ist die zentrale Navigationsstruktur und ermöglicht schnellen Zugriff auf die verschiedenen Module. Die Anzeige der Menüeinträge kann **rollenbasiert** angepasst werden, sodass Nutzende nur die für sie relevanten Funktionen sehen.
 
@@ -112,21 +112,21 @@ Das Hauptmenü von calServer ist die zentrale Navigationsstruktur und ermöglich
 
 ---
 
-# 2. Navigation im System
+# Navigation im System
 
-## 2.1 Hauptnavigation (Seitenleiste)
+## Hauptnavigation (Seitenleiste)
 
 | Funktionen |
 | ---------- |
 | Das **Hauptmenü befindet sich links** und bleibt während der Nutzung sichtbar.<br>Durch einen Klick auf eine **Hauptkategorie** öffnet sich das zugehörige **Untermenü**.<br>Icons und Bezeichnungen erleichtern die schnelle Orientierung.<br>Nicht benötigte Menüeinträge können je nach **Rollen- und Berechtigungskonfiguration** ausgeblendet sein. |
 
-## 2.2 Top-Navigationsleiste (Infoleiste)
+## Top-Navigationsleiste (Infoleiste)
 
 | Funktionen |
 | ---------- |
 | Anzeige wichtiger **Systemmeldungen, Benachrichtigungen und Aufgaben**.<br>Zugriff auf das **Benutzerprofil und persönliche Einstellungen**.<br>Möglichkeit zum **schnellen Wechsel zwischen Hauptfunktionen** |
 
-## 2.3 Navigation auf der Seite
+## Navigation auf der Seite
 
 | Funktionen |
 | ---------- |

--- a/docs/einleitung/systemanforderungen.md
+++ b/docs/einleitung/systemanforderungen.md
@@ -12,7 +12,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 1. Softwareanforderungen
+## Softwareanforderungen
 
 ### Für Server-Hosting (On-Premise Installation)
 
@@ -35,7 +35,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 2. Hardwareanforderungen
+## Hardwareanforderungen
 
 ### Für Server (On-Premise Hosting)
 
@@ -61,7 +61,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 3. Netzwerk- & Sicherheitsanforderungen
+## Netzwerk- & Sicherheitsanforderungen
 
 - **SSL-Verschlüsselung (HTTPS)** ist zwingend erforderlich für den sicheren Datentransfer.
 - **Firewall-Regeln:** Portfreigabe für Webserver (Standard: 443 HTTPS, 80 HTTP nur für Weiterleitungen).
@@ -71,7 +71,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 4. Passwort-Richtlinie
+## Passwort-Richtlinie
 
 - Passwörter müssen den **üblichen Sicherheitskriterien** entsprechen
 - Kunden können eigene Regeln konfigurieren (Mindestlänge, Sonderzeichen, Ablaufdatum etc.)
@@ -80,7 +80,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 5. Spam- & Cookie-Richtlinien
+## Spam- & Cookie-Richtlinien
 
 - calServer bietet **Sicherheitsmechanismen** wie Captcha-Formularschutz
 - Diese können vom Kunden konfiguriert werden
@@ -88,7 +88,7 @@ calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgeb
 
 ---
 
-## 6. Skalierbarkeit & Performance
+## Skalierbarkeit & Performance
 
 - **Dynamische Skalierung möglich** bei Cloud-Hosting (Lastverteilung über mehrere Instanzen)
 - **Cache-Unterstützung:** Redis oder Memcached für optimierte Performance

--- a/docs/einleitung/ueberblick-ueber-die-funktionen.md
+++ b/docs/einleitung/ueberblick-ueber-die-funktionen.md
@@ -12,7 +12,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 1. Allgemeine Systemfunktionen
+## Allgemeine Systemfunktionen
 
 - **Responsive Design** – Optimale Darstellung auf jedem Endgerät
 - **Mehrsprachigkeit** – Anpassbare Übersetzungen für internationale Nutzung
@@ -20,7 +20,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 2. Startcenter & Dashboards
+## Startcenter & Dashboards
 
 - **Individuelle Dashboards** – Nutzerbezogen konfigurierbare Startseiten
 - **Globale Dashboards** – Freigabe von Dashboards für Teams
@@ -28,7 +28,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 3. Inventarverwaltung
+## Inventarverwaltung
 
 - **Dynamische Inventartabellen** – Nutzerbezogene Spaltenanpassung
 - **Echtzeitsuche & Filter** – Erweiterte Suchfunktionen mit Statusfarben
@@ -38,7 +38,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 4. Kalibrierverwaltung
+## Kalibrierverwaltung
 
 - **Kalibrierstatus-Verwaltung** – Individuelle Statusvergabe mit Detaillog
 - **Automatische Benachrichtigungen** bei Statusänderungen
@@ -48,7 +48,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 5. Aufgabenmanagement
+## Aufgabenmanagement
 
 - **Inventar-Favoritenliste** – Schnellzugriff auf ausgewählte Geräte
 - **Kommentarfunktion für Inventare** – Anmerkungen zu Geräten hinzufügen
@@ -56,7 +56,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 6. Standorte
+## Standorte
 
 - **Kalendergestützte Reservierung** – Planung und Verwaltung von Messmitteln
 - **Drag & Drop-Reservierung** aus auswählbaren Listen
@@ -65,7 +65,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 7. Auftragsmanagement
+## Auftragsmanagement
 
 - **Bestellübersicht & Statusverfolgung**
 - **Verhandlungsmanagement** – Ablaufsteuerung zur Freigabe oder Stornierung
@@ -74,7 +74,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 8. Reporting & Berichte
+## Reporting & Berichte
 
 - **Individuelle Listen & Vorlagen** zur Auswertung
 - **Export in PDF, CSV, XLSX oder direkter Druck**
@@ -83,7 +83,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 9. Dokumentenmanagement
+## Dokumentenmanagement
 
 - **Automatische Integration von Kalibrierscheinen** in die Übersicht
 - **Versionsverwaltung für Dokumente** zu Inventaren und Kalibrierungen
@@ -91,7 +91,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 10. Benutzerverwaltung & Berechtigungssystem
+## Benutzerverwaltung & Berechtigungssystem
 
 - **Registrierung neuer Benutzer mit AGB-Bestätigung**
 - **Benutzerprofile mit individuellen Einstellungen**
@@ -100,7 +100,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 11. Kundenverwaltung
+## Kundenverwaltung
 
 - **Verwaltung von Unternehmens- & Kundenprofilen**
 - **Kundenindividuelle Inventarzuweisung & Detailinformationen**
@@ -108,7 +108,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 12. Angebots- & Rechnungsverwaltung
+## Angebots- & Rechnungsverwaltung
 
 - **Kostenvoranschläge & Preismanagement**
 - **Statusverfolgung von Angeboten & Bestellungen**
@@ -116,7 +116,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 13. API & Schnittstellen
+## API & Schnittstellen
 
 - **REST API zur Integration mit anderen Systemen** (siehe **Kapitel 8.5 REST API**)
 - **Automatisierte Datensynchronisation** mit externen Anwendungen
@@ -124,7 +124,7 @@ calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerro
 
 ---
 
-## 14. Sicherheit & Benachrichtigungen
+## Sicherheit & Benachrichtigungen
 
 - **Email-Benachrichtigungen bei neuen Anmeldungen & Fehlern**
 - **Debugmodus zur Fehleranalyse**


### PR DESCRIPTION
## Summary
- remove chapter numbers from various page headings
- pin the table-of-contents menu to the right side

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: could not fetch specs)*

------
https://chatgpt.com/codex/tasks/task_e_683d5a3d92cc832b853ad6eeecc40f60