### PR TITLE
Fix TOC and add bookmarks

### DIFF
--- a/_includes/bookmarks.html
+++ b/_includes/bookmarks.html
@@ -1,0 +1,5 @@
+<ul class="bookmarks">
+  <li>⏰ <a href="#bookmark1">Bookmark&nbsp;1</a></li>
+  <li>⏰ <a href="#bookmark2">Bookmark&nbsp;2</a></li>
+  <li>⏰ <a href="#bookmark3">Bookmark&nbsp;3</a></li>
+</ul>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,4 @@
-{% if page.toc %}
 <nav aria-label="Inhaltsverzeichnis" class="toc">
   <h2 class="text-delta" id="toc-title">Inhaltsverzeichnis</h2>
-  {{ page.toc }}
+  {{ content | toc_only }}
 </nav>
-{% endif %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -38,16 +38,25 @@ nav.toc ul {
   padding-left: 0;
 }
 
+.bookmarks {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 1rem;
+}
+.bookmarks li {
+  margin-bottom: 0.25rem;
+}
+
 /* TOC styling for medium and large screens */
 @media screen and (min-width: 60rem) {
   nav.toc {
     position: fixed;
     right: 2rem;
     top: 4rem;
-    width: 18rem;
+    width: 14rem;
   }
   main {
-    margin-right: 20rem;
+    margin-right: 16rem;
   }
 }
 

--- a/docs/administration/backup-wiederherstellungsmanagement.md
+++ b/docs/administration/backup-wiederherstellungsmanagement.md
@@ -7,6 +7,7 @@ layout: page
 
 # Backup- und Wiederherstellungsmanagement
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/benutzerverwaltung.md
+++ b/docs/administration/benutzerverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Benutzerverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/berichtsverwaltung.md
+++ b/docs/administration/berichtsverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Berichtsverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/dateiverwaltung.md
+++ b/docs/administration/dateiverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Dateiverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/email-verwaltung.md
+++ b/docs/administration/email-verwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # E-Mail-Verwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/feldverwaltung.md
+++ b/docs/administration/feldverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Feldverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/grundeinstellungen.md
+++ b/docs/administration/grundeinstellungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Grundeinstellungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/hilfeverwaltung.md
+++ b/docs/administration/hilfeverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Hilfeverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/informationsverwaltung.md
+++ b/docs/administration/informationsverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Informationsverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/konstanten-fuer-feldvorgaben.md
+++ b/docs/administration/konstanten-fuer-feldvorgaben.md
@@ -7,6 +7,7 @@ layout: page
 
 # Konstanten für Feldvorgaben
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/statusverwaltung.md
+++ b/docs/administration/statusverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Statusverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/steuerungen.md
+++ b/docs/administration/steuerungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Steuerungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/support-verwaltung.md
+++ b/docs/administration/support-verwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Support-Verwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/administration/synchronisation.md
+++ b/docs/administration/synchronisation.md
@@ -7,6 +7,7 @@ layout: page
 
 # Synchronisation
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/aufgaben.md
+++ b/docs/anwendungsfunktionen/aufgaben.md
@@ -7,6 +7,7 @@ layout: page
 
 # Aufgaben
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/auftraege.md
+++ b/docs/anwendungsfunktionen/auftraege.md
@@ -7,6 +7,7 @@ layout: page
 
 # Aufträge
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/dateien.md
+++ b/docs/anwendungsfunktionen/dateien.md
@@ -7,6 +7,7 @@ layout: page
 
 # Dateien
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/dokumentationssystem.md
+++ b/docs/anwendungsfunktionen/dokumentationssystem.md
@@ -7,6 +7,7 @@ layout: page
 
 # Dokumentationssystem
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/inventare.md
+++ b/docs/anwendungsfunktionen/inventare.md
@@ -7,6 +7,7 @@ layout: page
 
 # Inventare
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/kalibrierungen.md
+++ b/docs/anwendungsfunktionen/kalibrierungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Kalibrierungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/kunden.md
+++ b/docs/anwendungsfunktionen/kunden.md
@@ -7,6 +7,7 @@ layout: page
 
 # Kunden
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/preise.md
+++ b/docs/anwendungsfunktionen/preise.md
@@ -7,6 +7,7 @@ layout: page
 
 # Preise
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/standorte.md
+++ b/docs/anwendungsfunktionen/standorte.md
@@ -7,6 +7,7 @@ layout: page
 
 # Standorte
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/startcenter.md
+++ b/docs/anwendungsfunktionen/startcenter.md
@@ -7,6 +7,7 @@ layout: page
 
 # Startcenter
 {% include toc.html %}
+{% include bookmarks.html %}
 
 Das Startcenter ist die zentrale Benutzeroberfläche des calServer-Systems. Es dient als personalisierbarer Einstiegspunkt und ermöglicht die individuelle Zusammenstellung von Dashboards mit Infoelementen (Widgets).
 

--- a/docs/anwendungsfunktionen/support-ticketsystem.md
+++ b/docs/anwendungsfunktionen/support-ticketsystem.md
@@ -7,6 +7,7 @@ layout: page
 
 # Support-Ticketsystem
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/anwendungsfunktionen/wartung-und-reparaturen.md
+++ b/docs/anwendungsfunktionen/wartung-und-reparaturen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Wartung und Reparaturen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
+++ b/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Benutzerprofil – Einstellungen und Verwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -7,6 +7,7 @@ layout: page
 
 # Grid-Funktionen in calServer
 {% include toc.html %}
+{% include bookmarks.html %}
 
 ## Grundlegender Aufbau des Grids
 

--- a/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
+++ b/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
@@ -7,6 +7,7 @@ layout: page
 
 # Hauptmenü und Navigation
 {% include toc.html %}
+{% include bookmarks.html %}
 
 ## Einführung
 

--- a/docs/benutzeroberflaeche/infoleiste-top-menue.md
+++ b/docs/benutzeroberflaeche/infoleiste-top-menue.md
@@ -7,6 +7,7 @@ layout: page
 
 # Infoleiste (TOP Menü)
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/einleitung/systemanforderungen.md
+++ b/docs/einleitung/systemanforderungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Systemanforderungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgebung bereitgestellt wird. Um eine reibungslose Nutzung zu gewährleisten, müssen bestimmte **Systemanforderungen** erfüllt sein. Diese Anforderungen sind abhängig von der **Hosting-Umgebung**, der **Anzahl der Anwendenden** und der **Nutzungsintensität**.
 

--- a/docs/einleitung/ueberblick-ueber-die-funktionen.md
+++ b/docs/einleitung/ueberblick-ueber-die-funktionen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Überblick über die Funktionen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerrolle individuell konfiguriert und kombiniert werden können. Die folgende Übersicht beschreibt die wichtigsten Systemfunktionen in verschiedenen Kategorien.
 

--- a/docs/einleitung/ziel-und-zweck-der-anwendung.md
+++ b/docs/einleitung/ziel-und-zweck-der-anwendung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Ziel und Zweck der Anwendung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 ## Einführung
 

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
@@ -7,6 +7,7 @@ layout: page
 
 # Minimale Grundeinrichtung des Systems
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
@@ -7,6 +7,7 @@ layout: page
 
 # Schnelleinstieg Praxisbeispiel
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
+++ b/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Benutzerrollen und Berechtigungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/sicherheitsmanagement/passwortverwaltung.md
+++ b/docs/sicherheitsmanagement/passwortverwaltung.md
@@ -7,6 +7,7 @@ layout: page
 
 # Passwortverwaltung
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
+++ b/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
@@ -7,6 +7,7 @@ layout: page
 
 # Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
+++ b/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
@@ -7,6 +7,7 @@ layout: page
 
 # CalServer interne Hilfsfunktionen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
+++ b/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
@@ -7,6 +7,7 @@ layout: page
 
 # Fehlerbehebung, Logs und Diagnose
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/installation-und-konfiguration.md
+++ b/docs/technische-informationen/installation-und-konfiguration.md
@@ -7,6 +7,7 @@ layout: page
 
 # Installation und Konfiguration
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/rest-api-schnittstellen-integration.md
+++ b/docs/technische-informationen/rest-api-schnittstellen-integration.md
@@ -7,6 +7,7 @@ layout: page
 
 # REST API – Schnittstellen & Integration
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/sicherheitsrichtlinien.md
+++ b/docs/technische-informationen/sicherheitsrichtlinien.md
@@ -7,6 +7,7 @@ layout: page
 
 # Sicherheitsrichtlinien
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }

--- a/docs/technische-informationen/systemanforderungen.md
+++ b/docs/technische-informationen/systemanforderungen.md
@@ -7,6 +7,7 @@ layout: page
 
 # Systemanforderungen
 {% include toc.html %}
+{% include bookmarks.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.
 {: .note }


### PR DESCRIPTION
## Summary
- fix TOC include to render correctly via `toc_only`
- style TOC so it doesn't take all the right side space
- add bookmark list with clock icons on each subpage

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d70b71450832ba16871319c5d0e3c