### PR TITLE
Fix GitHub Pages build timeout

### DIFF
--- a/_includes/reading_time.html
+++ b/_includes/reading_time.html
@@ -1,1 +1,3 @@
-<p class="reading-time">⏰ Geschätzte Lesezeit: {{ page.content | reading_time }}</p>
+{% assign words = page.content | number_of_words %}
+{% assign minutes = words | plus: 199 | divided_by: 200 %}
+<p class="reading-time">⏰ Geschätzte Lesezeit: {{ minutes }} Minuten</p>

--- a/_plugins/reading_time_filter.rb
+++ b/_plugins/reading_time_filter.rb
@@ -1,8 +1,0 @@
-module ReadingTimeFilter
-  def reading_time(input)
-    words = input.to_s.gsub(/<[^>]*>/, " ").split.size
-    minutes = (words / 200.0).ceil
-    "#{minutes} Minuten"
-  end
-end
-Liquid::Template.register_filter(ReadingTimeFilter)


### PR DESCRIPTION
## Summary
- remove custom Ruby plugin
- implement reading time directly in Liquid

## Testing
- `bundle exec jekyll build` *(fails: bundler couldn't run jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_683d7749e73c832b91f183196a09a160