### PR TITLE
Optimize reading time calculation

### DIFF
--- a/_includes/reading_time.html
+++ b/_includes/reading_time.html
@@ -1,3 +1,7 @@
-{% assign words = page.content | number_of_words %}
-{% assign minutes = words | plus: 199 | divided_by: 200 %}
-<p class="reading-time">⏰ Geschätzte Lesezeit: {{ minutes }} Minuten</p>
+{% if page.reading_minutes %}
+  <p class="reading-time">⏰ Geschätzte Lesezeit: {{ page.reading_minutes }} Minuten</p>
+{% else %}
+  {% assign words = page.content | split: ' ' | size %}
+  {% assign minutes = words | plus: 199 | divided_by: 200 %}
+  <p class="reading-time">⏰ Geschätzte Lesezeit: {{ minutes }} Minuten</p>
+{% endif %}

--- a/_plugins/reading_time_generator.rb
+++ b/_plugins/reading_time_generator.rb
@@ -1,0 +1,15 @@
+module Jekyll
+  class ReadingTimeGenerator < Generator
+    safe true
+    priority :low
+    def generate(site)
+      docs = site.pages
+      docs += site.respond_to?(:posts) ? site.posts.docs : []
+      docs.each do |page|
+        next if page.data.key?('reading_minutes')
+        word_count = page.content.to_s.split(/\s+/).length
+        page.data['reading_minutes'] = (word_count / 200.0).ceil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- compute reading time once per page via plugin
- show precomputed value if available, fall back to quick Liquid calculation

## Testing
- `bundle exec jekyll build -d test_site` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d9258db48832ba8afc116ce358616