### PR TITLE
Fix duplicate TOC

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -57,8 +57,20 @@ nav.toc ul {
     max-height: calc(100vh - 4rem);
     overflow-y: auto;
   }
-  main {
+main {
     margin-right: 16rem;
+  }
+}
+
+/* Use full width on large screens */
+main {
+  max-width: none;
+}
+
+/* Hide TOC on small screens */
+@media screen and (max-width: 59.99rem) {
+  nav.toc {
+    display: none;
   }
 }
 

--- a/docs/abomodelle.md
+++ b/docs/abomodelle.md
@@ -6,7 +6,6 @@ layout: page
 
 
 # Abomodelle
-{% include toc.html %}
 
 ## Kurzerklärung
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Administration
-{% include toc.html %}
 
 In diesem Kapitel erhalten Sie einen umfassenden Überblick über alle administrativen Funktionen von calServer. Erfahren Sie, wie Sie Grundeinstellungen vornehmen, Benutzer verwalten, Rollen und Berechtigungen definieren sowie zentrale Systemeinstellungen und Sicherheitsmaßnahmen effektiv einsetzen und verwalten.
 

--- a/docs/administration/backup-wiederherstellungsmanagement.md
+++ b/docs/administration/backup-wiederherstellungsmanagement.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Backup- und Wiederherstellungsmanagement
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/benutzerverwaltung.md
+++ b/docs/administration/benutzerverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Benutzerverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/berichtsverwaltung.md
+++ b/docs/administration/berichtsverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Berichtsverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/dateiverwaltung.md
+++ b/docs/administration/dateiverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Dateiverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/email-verwaltung.md
+++ b/docs/administration/email-verwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # E-Mail-Verwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/feldverwaltung.md
+++ b/docs/administration/feldverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Feldverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/grundeinstellungen.md
+++ b/docs/administration/grundeinstellungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Grundeinstellungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/hilfeverwaltung.md
+++ b/docs/administration/hilfeverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Hilfeverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/informationsverwaltung.md
+++ b/docs/administration/informationsverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Informationsverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/konstanten-fuer-feldvorgaben.md
+++ b/docs/administration/konstanten-fuer-feldvorgaben.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Konstanten für Feldvorgaben
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/statusverwaltung.md
+++ b/docs/administration/statusverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Statusverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/steuerungen.md
+++ b/docs/administration/steuerungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Steuerungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/support-verwaltung.md
+++ b/docs/administration/support-verwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Support-Verwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/administration/synchronisation.md
+++ b/docs/administration/synchronisation.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Synchronisation
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen.md
+++ b/docs/anwendungsfunktionen.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Anwendungsfunktionen
-{% include toc.html %}
 
 Dieses Kapitel stellt Ihnen die wichtigsten Anwendungsfunktionen von calServer im Detail vor. Sie erhalten praktische Einblicke und Erklärungen zu den verschiedenen Modulen, um die Arbeitsprozesse rund um Inventarverwaltung, Kalibrierungen, Wartungen und weitere Aufgaben effizient und zielgerichtet durchführen zu können.
 

--- a/docs/anwendungsfunktionen/aufgaben.md
+++ b/docs/anwendungsfunktionen/aufgaben.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Aufgaben
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/auftraege.md
+++ b/docs/anwendungsfunktionen/auftraege.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Aufträge
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/dateien.md
+++ b/docs/anwendungsfunktionen/dateien.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Dateien
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/dokumentationssystem.md
+++ b/docs/anwendungsfunktionen/dokumentationssystem.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Dokumentationssystem
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/inventare.md
+++ b/docs/anwendungsfunktionen/inventare.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Inventare
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/kalibrierungen.md
+++ b/docs/anwendungsfunktionen/kalibrierungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Kalibrierungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/kunden.md
+++ b/docs/anwendungsfunktionen/kunden.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Kunden
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/preise.md
+++ b/docs/anwendungsfunktionen/preise.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Preise
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/standorte.md
+++ b/docs/anwendungsfunktionen/standorte.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Standorte
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/startcenter.md
+++ b/docs/anwendungsfunktionen/startcenter.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Startcenter
-{% include toc.html %}
 {% include reading_time.html %}
 
 Das Startcenter ist die zentrale Benutzeroberfläche des calServer-Systems. Es dient als personalisierbarer Einstiegspunkt und ermöglicht die individuelle Zusammenstellung von Dashboards mit Infoelementen (Widgets).

--- a/docs/anwendungsfunktionen/support-ticketsystem.md
+++ b/docs/anwendungsfunktionen/support-ticketsystem.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Support-Ticketsystem
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/anwendungsfunktionen/wartung-und-reparaturen.md
+++ b/docs/anwendungsfunktionen/wartung-und-reparaturen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Wartung und Reparaturen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/benutzeroberflaeche.md
+++ b/docs/benutzeroberflaeche.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Benutzeroberfläche
-{% include toc.html %}
 
 Dieses Kapitel bietet Ihnen eine übersichtliche Einführung in den Aufbau und die wichtigsten Funktionen der calServer-Benutzeroberfläche – von der Navigation über die Nutzung zentraler Bedienelemente bis hin zur Anpassung der Arbeitsumgebung nach individuellen Anforderungen.
 

--- a/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
+++ b/docs/benutzeroberflaeche/benutzerprofil-einstellungen-und-verwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Benutzerprofil – Einstellungen und Verwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/benutzeroberflaeche/das-grid.md
+++ b/docs/benutzeroberflaeche/das-grid.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Grid-Funktionen in calServer
-{% include toc.html %}
 {% include reading_time.html %}
 
 ## Grundlegender Aufbau des Grids

--- a/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
+++ b/docs/benutzeroberflaeche/hauptmenue-und-navigation.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Hauptmenü und Navigation
-{% include toc.html %}
 {% include reading_time.html %}
 
 ## Einführung

--- a/docs/benutzeroberflaeche/infoleiste-top-menue.md
+++ b/docs/benutzeroberflaeche/infoleiste-top-menue.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Infoleiste (TOP Menü)
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/einleitung.md
+++ b/docs/einleitung.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Einleitung
-{% include toc.html %}
 
 Dieses Kapitel führt Sie gezielt in die Anwendung calServer ein. Sie erfahren, welchen Nutzen die Software für Ihre tägliche Arbeit bietet, erhalten einen kompakten Überblick über den Funktionsumfang und lernen die grundlegenden technischen Anforderungen kennen, um optimal mit calServer zu arbeiten.
 

--- a/docs/einleitung/systemanforderungen.md
+++ b/docs/einleitung/systemanforderungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Systemanforderungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 calServer ist eine **webbasierte Cloud-Anwendung**, die in einer Container-Umgebung bereitgestellt wird. Um eine reibungslose Nutzung zu gewährleisten, müssen bestimmte **Systemanforderungen** erfüllt sein. Diese Anforderungen sind abhängig von der **Hosting-Umgebung**, der **Anzahl der Anwendenden** und der **Nutzungsintensität**.

--- a/docs/einleitung/ueberblick-ueber-die-funktionen.md
+++ b/docs/einleitung/ueberblick-ueber-die-funktionen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Überblick über die Funktionen
-{% include toc.html %}
 {% include reading_time.html %}
 
 calServer bietet eine Vielzahl an Modulen und Funktionen, die je nach Benutzerrolle individuell konfiguriert und kombiniert werden können. Die folgende Übersicht beschreibt die wichtigsten Systemfunktionen in verschiedenen Kategorien.

--- a/docs/einleitung/ziel-und-zweck-der-anwendung.md
+++ b/docs/einleitung/ziel-und-zweck-der-anwendung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Ziel und Zweck der Anwendung
-{% include toc.html %}
 {% include reading_time.html %}
 
 ## Einführung

--- a/docs/impressum.md
+++ b/docs/impressum.md
@@ -6,7 +6,6 @@ permalink: /impressum/
 ---
 
 # Impressum
-{% include toc.html %}
 
 Stand 29.04.2020
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,6 @@ permalink: /index.html
 *Stand: 2025-05-26*
 
 # Willkommen zum calServer Manual
-{% include toc.html %}
 
 **Herzlich willkommen zur offiziellen Dokumentation von calServer!**
 

--- a/docs/kontakt.md
+++ b/docs/kontakt.md
@@ -6,7 +6,6 @@ permalink: /kontakt/
 ---
 
 # Kontakt
-{% include toc.html %}
 
 Vereinbaren Sie einen kostenlosen Rückruf mit uns oder stellen Sie eine Anfrage \
 über das Kontaktformular. Als Kunde können Sie hier direkt auf unser \

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Schnelleinstieg und zentrale Arbeitsabläufe
-{% include toc.html %}
 
 Dieses Kapitel bietet Ihnen einen kompakten, praxisnahen Einstieg in die zentralen Arbeitsabläufe von calServer – von der Datenerfassung über die systematische Grundeinrichtung bis hin zur Nutzerverwaltung.
 

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/minimale-grundeinrichtung-des-systems.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Minimale Grundeinrichtung des Systems
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
+++ b/docs/schnelleinstieg-und-zentrale-arbeitsablaeufe/schnelleinstieg-praxisbeispiel.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Schnelleinstieg Praxisbeispiel
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/sicherheitsmanagement.md
+++ b/docs/sicherheitsmanagement.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Sicherheitsmanagement
-{% include toc.html %}
 
 Dieses Kapitel erläutert die Konzepte des Sicherheitsmanagements in calServer. Sie erfahren, wie Sie Benutzerrollen und Berechtigungen verwalten, Passwörter sicher handhaben und die Zugriffssicherheit sowie Sicherheitsprotokolle überwachen.
 

--- a/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
+++ b/docs/sicherheitsmanagement/benutzerrollen-und-berechtigungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Benutzerrollen und Berechtigungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/sicherheitsmanagement/passwortverwaltung.md
+++ b/docs/sicherheitsmanagement/passwortverwaltung.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Passwortverwaltung
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
+++ b/docs/sicherheitsmanagement/verwaltung-der-zugriffssicherheit-und-sicherheitsprotokolle.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Verwaltung der Zugriffssicherheit und Sicherheitsprotokolle
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen.md
+++ b/docs/technische-informationen.md
@@ -6,7 +6,6 @@ has_children: True
 ---
 
 # Technische Informationen
-{% include toc.html %}
 
 In diesem Kapitel finden Sie detaillierte technische Informationen zu calServer, einschließlich Systemanforderungen, Installationsanweisungen, Hilfestellungen bei Fehlern und Problemen sowie Erläuterungen zu den internen Hilfsfunktionen und der integrierten REST-API für externe Schnittstellenkommunikation.
 

--- a/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
+++ b/docs/technische-informationen/calserver-interne-hilfsfunktionen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # CalServer interne Hilfsfunktionen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
+++ b/docs/technische-informationen/fehlerbehebung-logs-diagnose.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Fehlerbehebung, Logs und Diagnose
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen/installation-und-konfiguration.md
+++ b/docs/technische-informationen/installation-und-konfiguration.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Installation und Konfiguration
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen/rest-api-schnittstellen-integration.md
+++ b/docs/technische-informationen/rest-api-schnittstellen-integration.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # REST API – Schnittstellen & Integration
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen/sicherheitsrichtlinien.md
+++ b/docs/technische-informationen/sicherheitsrichtlinien.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Sicherheitsrichtlinien
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/technische-informationen/systemanforderungen.md
+++ b/docs/technische-informationen/systemanforderungen.md
@@ -6,7 +6,6 @@ layout: page
 ---
 
 # Systemanforderungen
-{% include toc.html %}
 {% include reading_time.html %}
 
 > **Hinweis:** Diese Seite befindet sich noch in Bearbeitung.

--- a/docs/versionen.md
+++ b/docs/versionen.md
@@ -5,7 +5,6 @@ nav_order: 10
 ---
 
 # Versionshinweise
-{% include toc.html %}
 
 Hier finden Sie eine Übersicht der wichtigsten Änderungen und Versionshinweise zu calServer.
 


### PR DESCRIPTION
## Summary
- remove `{% include toc.html %}` from all docs so the table of contents only renders once
- keep style tweaks for wide layout and mobile TOC hiding

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d9401063c832bb84bc6ef9dc737ca