### PR TITLE
Expand content area

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -56,14 +56,18 @@ nav.toc ul {
     width: 14rem;
     max-height: calc(100vh - 4rem);
     overflow-y: auto;
+    float: right;
+    margin-left: 1rem;
   }
-main {
-    margin-right: 16rem;
+  main {
+    margin-right: 0;
   }
 }
 
 /* Use full width on large screens */
-main {
+main,
+.main-content,
+.main-content-wrap {
   max-width: none;
 }
 


### PR DESCRIPTION
## Summary
- let the table of contents float to the right
- remove extra right margin for the main area
- allow main content containers to use the full width

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683da5086fd4832b92676997e2983036